### PR TITLE
fix: --env now replaces existing SDL env vars instead of duplicating

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 112
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-26T15:58:25Z"
+  "generated_at": "2026-04-27T20:44:12Z"
 }

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -66,19 +66,25 @@ def _inject_env_into_sdl(sdl_content: str, env_vars: list[str]) -> str:
     if not env_vars:
         return sdl_content
     override_keys = {v.split("=", 1)[0] for v in env_vars}
-    lines = sdl_content.splitlines(keepends=True)
-    sdl_content = "".join(
-        line
-        for line in lines
-        if not any(re.match(r"\s*- " + re.escape(key) + r"=", line) for key in override_keys)
-    )
     env_match = re.search(r"^(\s+)env:\s*\n", sdl_content, re.MULTILINE)
     if env_match:
         indent = env_match.group(1)
         entry_indent = indent + "  "
-        insert_pos = env_match.end()
+        block_start = env_match.end()
+        remaining = sdl_content[block_start:]
+        lines = remaining.splitlines(keepends=True)
+        kept = []
+        consumed = 0
+        for line in lines:
+            stripped = line.rstrip("\n")
+            if stripped and not stripped.startswith(entry_indent):
+                break
+            consumed += len(line)
+            if any(re.match(r"\s*- " + re.escape(key) + r"=", line) for key in override_keys):
+                continue
+            kept.append(line)
         new_entries = "".join(f"{entry_indent}- {var}\n" for var in env_vars)
-        return sdl_content[:insert_pos] + new_entries + sdl_content[insert_pos:]
+        return sdl_content[:block_start] + new_entries + "".join(kept) + remaining[consumed:]
     expose_match = re.search(r"^(\s+)expose:\s*\n", sdl_content, re.MULTILINE)
     if expose_match:
         indent = expose_match.group(1)

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -65,6 +65,13 @@ def _log_bid_table(bids: list, label: str):
 def _inject_env_into_sdl(sdl_content: str, env_vars: list[str]) -> str:
     if not env_vars:
         return sdl_content
+    override_keys = {v.split("=", 1)[0] for v in env_vars}
+    lines = sdl_content.splitlines(keepends=True)
+    sdl_content = "".join(
+        line
+        for line in lines
+        if not any(re.match(r"\s*- " + re.escape(key) + r"=", line) for key in override_keys)
+    )
     env_match = re.search(r"^(\s+)env:\s*\n", sdl_content, re.MULTILINE)
     if env_match:
         indent = env_match.group(1)


### PR DESCRIPTION
## Summary

- `--env KEY=VALUE` now **replaces** any existing `- KEY=...` entry in the SDL `env:` block instead of prepending a duplicate
- Before injecting new env vars, removes any existing lines matching the override keys using a regex match on `  - KEY=`

## Reproduction

Given an SDL with `env: - GGUF_URL=https://example.com/model-A.gguf`, running `just-akash deploy --sdl app.yaml --env "GGUF_URL=https://example.com/model-B.gguf"` would previously produce two entries, with the SDL default (last) winning silently.

## Testing

All 22 existing tests pass. The fix is isolated to `_inject_env_into_sdl()` in `deploy.py`.

Fixes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable updates now deduplicate keys: applying new values removes prior entries with the same keys so overrides take effect and duplicate entries no longer remain.

* **Chores**
  * Secret baseline metadata regenerated with an updated timestamp and adjusted line metadata for a detected entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->