### PR TITLE
Document Digital Frontier maintainership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,13 @@ jobs:
   e2e-secrets:
     name: E2E secrets injection
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Run after e2e-shell, never alongside it: both jobs deploy with the same
+    # AKASH_API_KEY (one Akash account). Concurrent runs collide on the same
+    # deployment and the stale-deployment recovery in deploy.py tears down the
+    # other job's live deployment — surfacing as "manifest version validation
+    # failed" (422) and "lease not active". Serializing keeps each job isolated.
+    needs: e2e-shell
+    if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
     env:
       AKASH_API_KEY: ${{ secrets.AKASH_API_KEY }}
       AKASH_PROVIDERS: ${{ secrets.AKASH_PROVIDERS }}

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -22,10 +22,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Run the gitleaks binary directly rather than gitleaks/gitleaks-action@v2.
+      # The v2 action requires a paid GITLEAKS_LICENSE for organization repos;
+      # the CLI itself is free and unlicensed and scans the full history.
+      - name: Install gitleaks
+        run: |
+          VERSION=8.21.2
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gitleaks detect --source . --redact --verbose --exit-code 1
 
   trufflehog:
     name: TruffleHog

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -28,8 +28,12 @@ jobs:
       - name: Install gitleaks
         run: |
           VERSION=8.21.2
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+          SHA256=5bc41815076e6ed6ef8fbecc9d9b75bcae31f39029ceb55da08086315316e3ba
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
+          echo "${SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz -C /usr/local/bin gitleaks
+          rm -f gitleaks.tar.gz
           gitleaks version
 
       - name: Run gitleaks

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -212,7 +212,7 @@
         "filename": "just_akash/api.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 612
+        "line_number": 652
       }
     ],
     "just_akash/deploy.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T16:21:26Z"
+  "generated_at": "2026-06-01T18:53:20Z"
 }

--- a/Justfile
+++ b/Justfile
@@ -266,17 +266,7 @@ akash-node-lcd:
     #!/bin/bash
     set -euo pipefail
     status_json="$(uv run just-akash status --json --dseq akash-node 2>/dev/null || true)"
-    printf '%s' "$status_json" | python3 -c '
-import sys, json
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-for e in data.get("endpoints", []):
-    if e.get("internal_port") == 1317:
-        print("http://" + str(e["host"]) + ":" + str(e["port"]))
-        break
-'
+    printf '%s' "$status_json" | python3 -c 'import sys, json; d = json.loads(sys.stdin.read() or "{}"); e = next((x for x in d.get("endpoints", []) if x.get("internal_port") == 1317), None); print("http://" + str(e["host"]) + ":" + str(e["port"])) if e else None'
 
 # Destroy the akash-node deployment.
 down-akash-node:

--- a/Justfile
+++ b/Justfile
@@ -231,5 +231,53 @@ deploy sdl="sdl/cpu-backtest-ssh.yaml" image="":
     if [ -n "{{image}}" ]; then cmd="$cmd --image {{image}}"; fi
     eval "$cmd"
 
+# ── Akash node (personal LCD/RPC) ────────────────────
+
+# Spin up a personal Akash LCD/RPC node via cosmos-omnibus.
+# Bootstraps from the official snapshot, runs PRUNING=nothing forward so it
+# becomes archival from the snapshot's block onward. See sdl/akash-node.yaml.
+# Tags the deployment "akash-node" for reuse: `just status akash-node`.
+up-akash-node:
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/up-akash-node-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=up-akash-node finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=up-akash-node started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file"
+    set -x
+    uv run just-akash deploy --sdl sdl/akash-node.yaml --bid-wait 60 --bid-wait-retry 120 | tee /tmp/.akash-node-deploy.log
+    dseq=$(sed -n 's/.*DSEQ: \([0-9]*\).*/\1/p' /tmp/.akash-node-deploy.log | head -1)
+    if [ -n "$dseq" ]; then
+        uv run just-akash tag --dseq "$dseq" --name akash-node
+        echo
+        echo "Akash node deployed. Boot takes ~15-25 min (snapshot stream + extract + sync)."
+        echo "Check progress:    just status akash-node"
+        echo "Tail node logs:    just connect akash-node lease-shell"
+        echo "Once LCD is up:    akash-wallet-audit --api-base http://<host>:1317"
+    fi
+
+# Print just the LCD URL of the running akash-node deployment.
+# Convenience helper — parses provider URIs out of `status` output.
+akash-node-lcd:
+    #!/bin/bash
+    set -euo pipefail
+    uv run just-akash status --dseq akash-node 2>/dev/null \
+      | grep -Eo 'https?://[^[:space:]]+:1317[^[:space:]]*' \
+      | head -1
+
+# Destroy the akash-node deployment.
+down-akash-node:
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/down-akash-node-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=down-akash-node finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    set -x
+    uv run just-akash destroy --dseq akash-node
+
 # ── Variables ────────────────────────────────────────
 log_dir := ".logs/just"

--- a/Justfile
+++ b/Justfile
@@ -247,8 +247,10 @@ up-akash-node:
     trap 'status=$?; echo "[INFO] recipe=up-akash-node finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=up-akash-node started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file"
     set -x
-    uv run just-akash deploy --sdl sdl/akash-node.yaml --bid-wait 60 --bid-wait-retry 120 | tee /tmp/.akash-node-deploy.log
-    dseq=$(sed -n 's/.*DSEQ: \([0-9]*\).*/\1/p' /tmp/.akash-node-deploy.log | head -1)
+    deploy_log="$(mktemp -t akash-node-deploy.XXXXXX.log)"
+    uv run just-akash deploy --sdl sdl/akash-node.yaml --bid-wait 60 --bid-wait-retry 120 | tee "$deploy_log"
+    dseq=$(sed -n 's/.*DSEQ: \([0-9]*\).*/\1/p' "$deploy_log" | head -1)
+    rm -f "$deploy_log"
     if [ -n "$dseq" ]; then
         uv run just-akash tag --dseq "$dseq" --name akash-node
         echo

--- a/Justfile
+++ b/Justfile
@@ -259,13 +259,24 @@ up-akash-node:
     fi
 
 # Print just the LCD URL of the running akash-node deployment.
-# Convenience helper — parses provider URIs out of `status` output.
+# Convenience helper — reads the forwarded LCD endpoint (internal port 1317)
+# from `status --json`. Prints nothing until the lease is active and the
+# provider has published its forwarded ports.
 akash-node-lcd:
     #!/bin/bash
     set -euo pipefail
-    uv run just-akash status --dseq akash-node 2>/dev/null \
-      | grep -Eo 'https?://[^[:space:]]+:1317[^[:space:]]*' \
-      | head -1
+    status_json="$(uv run just-akash status --json --dseq akash-node 2>/dev/null || true)"
+    printf '%s' "$status_json" | python3 -c '
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for e in data.get("endpoints", []):
+    if e.get("internal_port") == 1317:
+        print("http://" + str(e["host"]) + ":" + str(e["port"]))
+        break
+'
 
 # Destroy the akash-node deployment.
 down-akash-node:
@@ -276,6 +287,7 @@ down-akash-node:
     log_file="{{log_dir}}/down-akash-node-${timestamp}.log"
     exec > >(tee -a "$log_file") 2>&1
     trap 'status=$?; echo "[INFO] recipe=down-akash-node finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=down-akash-node started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file"
     set -x
     uv run just-akash destroy --dseq akash-node
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,37 @@ uv run just-akash destroy --dseq 12345
 uv run just-akash tag --dseq 12345 --name my-job
 ```
 
+## Run a personal Akash LCD/RPC node
+
+`just up-akash-node` deploys a cosmos-omnibus node (chain `akashnet-2`) that
+exposes a REST/LCD endpoint on port 1317, Tendermint RPC on 26657, and gRPC on
+9090. It bootstraps from the official Akash snapshot
+(`snapshots.akash.network/akashnet-2/latest`, refreshed hourly) and runs
+`PRUNING=nothing` from there, so it's archival **going forward** from the
+snapshot's height. No publicly-hosted Akash archive snapshot exists at the
+moment — for older historical heights, an alternate LCD is still needed.
+
+```bash
+just up-akash-node              # deploy and tag "akash-node"
+just status akash-node          # see provider URIs (boot ~15-25 min)
+just akash-node-lcd             # prints the LCD URL once provisioned
+just down-akash-node            # destroy when done
+```
+
+After the LCD URL is available:
+
+```bash
+akash-wallet-audit --api-base http://<host>:1317
+```
+
+The boot timeline is roughly 3-5 min to stream the ~10 GB lz4 snapshot, 10-15
+min to extract it in-process, plus a short catch-up sync. The default SDL
+asks for 4 vCPU / 16 GiB RAM / 250 GiB beta3 persistent storage with a price
+ceiling of `100000 uact` per block — providers bid down from there.
+
+The LCD is exposed publicly with no auth (fine for read-only queries; put a
+proxy in front if this becomes a long-running node).
+
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Justfile recipes + Python CLI for deploying on [Akash Network](https://akash.net
 
 Self-contained — clone, configure `.env`, and run.
 
+> **Maintenance & ownership.** As of June 2026, `just-akash` is maintained by
+> [Digital Frontier](https://github.com/Digital-Frontier-LDA) (MIT-licensed). It's part of our
+> commitment to making Akash enterprise-ready — adding robustness to the deployment lifecycle and
+> security to post-deploy operations (no-SSH lease-shell exec, off-SDL secret injection).
+
 ## What's New in v1.6.0
 
 - **Tiered provider selection** — preferred + backup allowlists with a 3-phase bid-selection state machine (`AKASH_PROVIDERS_BACKUP` env var, `--provider` / `--backup-provider` CLI flags). See [Bid Selection](#bid-selection).
@@ -20,7 +25,7 @@ Self-contained — clone, configure `.env`, and run.
 ## Setup
 
 ```bash
-git clone https://github.com/jobordu/just-akash
+git clone https://github.com/Digital-Frontier-LDA/just-akash
 cd just-akash
 cp .env.example .env
 # Edit .env — add your API key, providers, SSH pubkey

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -455,6 +455,46 @@ def _extract_ssh_info(deployment: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _extract_forwarded_ports(deployment: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return every forwarded port a lease exposes.
+
+    Each entry is ``{"internal_port", "host", "port", "service"}`` where ``port``
+    is the provider-assigned external port. Used to surface non-SSH endpoints
+    (e.g. an LCD/REST server on internal port 1317) that ``_extract_ssh_info``
+    deliberately ignores.
+    """
+    endpoints: list[dict[str, Any]] = []
+    leases = deployment.get("leases")
+    for lease in leases if isinstance(leases, list) else []:
+        if not isinstance(lease, dict):
+            continue
+        status = lease.get("status") or {}
+        if not isinstance(status, dict):
+            continue
+        fwd_ports = status.get("forwarded_ports") or {}
+        if not isinstance(fwd_ports, dict):
+            continue
+        for svc_name, ports in fwd_ports.items():
+            if not isinstance(ports, list):
+                continue
+            for p in ports:
+                if not isinstance(p, dict):
+                    continue
+                host = p.get("host")
+                external_port = p.get("externalPort")
+                internal_port = p.get("port")
+                if host is not None and external_port is not None:
+                    endpoints.append(
+                        {
+                            "internal_port": internal_port,
+                            "host": host,
+                            "port": external_port,
+                            "service": svc_name,
+                        }
+                    )
+    return endpoints
+
+
 def _extract_lease_provider(deployment: dict[str, Any]) -> str | None:
     leases = deployment.get("leases")
     for lease in leases if isinstance(leases, list) else []:

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -483,7 +483,7 @@ def _extract_forwarded_ports(deployment: dict[str, Any]) -> list[dict[str, Any]]
                 host = p.get("host")
                 external_port = p.get("externalPort")
                 internal_port = p.get("port")
-                if host is not None and external_port is not None:
+                if host is not None and external_port is not None and internal_port is not None:
                     endpoints.append(
                         {
                             "internal_port": internal_port,

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -449,6 +449,7 @@ def main():
     elif args.command == "status":
         from .api import (
             AkashConsoleAPI,
+            _extract_forwarded_ports,
             _extract_lease_provider,
             _extract_ssh_info,
             _get_tag,
@@ -485,6 +486,9 @@ def main():
                     result["endpoint"] = f"ssh -p {ssh['port']} root@{ssh['host']}"
                     result["ssh_host"] = ssh["host"]
                     result["ssh_port"] = ssh["port"]
+                forwarded = _extract_forwarded_ports(deployment)
+                if forwarded:
+                    result["endpoints"] = forwarded
                 print(_json_output(result))
             else:
                 tag = _get_tag(dseq)

--- a/just_akash/test_shell_e2e.py
+++ b/just_akash/test_shell_e2e.py
@@ -141,7 +141,10 @@ def main():
 
         if not lease_ready:
             failures.append("lease_timeout")
-            log_fail(f"Lease not active after {10 + max_attempts * poll_interval} seconds")
+            # 10s initial sleep + a poll_interval sleep after every attempt but
+            # the last (the final check has no trailing sleep).
+            max_wait = 10 + (max_attempts - 1) * poll_interval
+            log_fail(f"Lease not active after {max_wait} seconds")
         else:
             log_pass("Lease is active and ready")
 

--- a/just_akash/test_shell_e2e.py
+++ b/just_akash/test_shell_e2e.py
@@ -118,7 +118,11 @@ def main():
 
         lease_ready = False
         provider_addr = None
-        for attempt in range(1, 6):
+        # Provider workload activation can lag well past 35s on a busy provider;
+        # poll up to ~95s before declaring a timeout to avoid flaky CI failures.
+        max_attempts = 18
+        poll_interval = 5
+        for attempt in range(1, max_attempts + 1):
             r = run(f"uv run just-akash status --dseq {dseq} --json", timeout=30)
             try:
                 status_data = json.loads(r.stdout)
@@ -128,13 +132,16 @@ def main():
                     break
             except (json.JSONDecodeError, TypeError):
                 pass
-            if attempt < 5:
-                log_info(f"Attempt {attempt}/5 — lease not ready yet, retrying in 5s...")
-                time.sleep(5)
+            if attempt < max_attempts:
+                log_info(
+                    f"Attempt {attempt}/{max_attempts} — lease not ready yet, "
+                    f"retrying in {poll_interval}s..."
+                )
+                time.sleep(poll_interval)
 
         if not lease_ready:
             failures.append("lease_timeout")
-            log_fail("Lease not active after 35 seconds")
+            log_fail(f"Lease not active after {10 + max_attempts * poll_interval} seconds")
         else:
             log_pass("Lease is active and ready")
 

--- a/sdl/akash-node.yaml
+++ b/sdl/akash-node.yaml
@@ -35,7 +35,11 @@ services:
       - AKASH_API_ENABLE=true
       - AKASH_API_ADDRESS=tcp://0.0.0.0:1317
       - AKASH_API_SWAGGER=true
-      - AKASH_API_ENABLED_UNSAFE_CORS=true
+      # CORS stays disabled by default: the LCD port is exposed globally and the
+      # documented consumers are CLIs (e.g. akash-wallet-audit), which don't need
+      # cross-origin browser access. Set this to true only if you serve a browser
+      # app from another origin against this endpoint.
+      - AKASH_API_ENABLED_UNSAFE_CORS=false
       # gRPC for non-LCD clients.
       - AKASH_GRPC_ENABLE=true
       - AKASH_GRPC_ADDRESS=0.0.0.0:9090

--- a/sdl/akash-node.yaml
+++ b/sdl/akash-node.yaml
@@ -1,0 +1,93 @@
+---
+# Personal Akash LCD/RPC node (cosmos-omnibus).
+#
+# What this gives us:
+#   - REST/LCD on port 1317 — `/cosmos/bank/...`, `/cosmos/tx/v1beta1/txs`, etc.
+#   - Tendermint RPC on 26657, gRPC on 9090
+#   - Bootstrap from snapshots.akash.network (updated hourly, ~10 GB lz4)
+#   - PRUNING=nothing — every new height retained, so the node becomes
+#     archival going FORWARD from the snapshot's block. Older heights stay
+#     pruned (no public Akash archive snapshot exists as of 2026-05).
+#
+# Boot timeline: ~3–5 min download + ~10–15 min in-process lz4 extract +
+# minutes of catch-up sync. LCD is reachable once the node is past the
+# snapshot height.
+#
+# Security note: ports are exposed globally with no auth. Fine for read-only
+# bank/tx queries; if this becomes a long-running node, put it behind an
+# auth-aware proxy.
+version: "2.0"
+
+services:
+  node:
+    image: ghcr.io/akash-network/cosmos-omnibus:v1.2.43-akash-v2.0.1
+    env:
+      - MONIKER=just-akash-fwd-archive
+      - CHAIN_JSON=https://raw.githubusercontent.com/akash-network/net/main/mainnet/meta.json
+      # Bootstrap from the official Akash snapshot. The endpoint 302s to the
+      # current `akashnet-2_<height>.tar.lz4`, so we pin the FORMAT explicitly
+      # (the URL ends in `latest`, not `.tar.lz4`, so auto-detection misfires).
+      - SNAPSHOT_URL=https://snapshots.akash.network/akashnet-2/latest
+      - SNAPSHOT_FORMAT=tar.lz4
+      # Archive going forward — keep every state from snapshot height onward.
+      - PRUNING=nothing
+      # Enable the REST/LCD server. Default is enable=false in app.toml.
+      - AKASH_API_ENABLE=true
+      - AKASH_API_ADDRESS=tcp://0.0.0.0:1317
+      - AKASH_API_SWAGGER=true
+      - AKASH_API_ENABLED_UNSAFE_CORS=true
+      # gRPC for non-LCD clients.
+      - AKASH_GRPC_ENABLE=true
+      - AKASH_GRPC_ADDRESS=0.0.0.0:9090
+      # Minimum gas price (relayed txs only — we don't sign anything).
+      - MINIMUM_GAS_PRICES=0.025uakt
+      # Pull live peers + addrbook from Polkachu so the catch-up sync finds
+      # peers quickly without a manual seed list.
+      - P2P_POLKACHU=1
+      - ADDRBOOK_POLKACHU=1
+    expose:
+      - port: 1317
+        as: 1317
+        to:
+          - global: true
+      - port: 26657
+        as: 26657
+        to:
+          - global: true
+      - port: 9090
+        as: 9090
+        to:
+          - global: true
+    params:
+      storage:
+        data:
+          mount: /root/.akash
+
+profiles:
+  compute:
+    node:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 16Gi
+        storage:
+          - size: 10Gi
+          - name: data
+            size: 250Gi
+            attributes:
+              persistent: true
+              class: beta3
+
+  placement:
+    akash:
+      pricing:
+        node:
+          denom: uact
+          amount: 100000
+
+deployment:
+  node:
+    akash:
+      profile: node
+      count: 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,46 @@ class TestCliStatusWithDseq:
         assert "active" in captured.out
 
 
+class TestCliStatusForwardedEndpoints:
+    @patch("just_akash.api._get_tag", return_value=None)
+    @patch("just_akash.api._extract_lease_provider", return_value="akash1prov")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_status_json_includes_lcd_endpoint(
+        self, MockAPI, mock_lease_prov, mock_tag, monkeypatch, capsys
+    ):
+        """status --json must surface forwarded non-SSH ports (e.g. LCD :1317).
+
+        Regression for the akash-node-lcd recipe: it parses status JSON for the
+        forwarded LCD endpoint, which previously was never emitted.
+        """
+        import json
+
+        monkeypatch.setenv("AKASH_API_KEY", "test-key")
+        client = MockAPI.return_value
+        client.get_deployment.return_value = {
+            "deployment": {"state": "active"},
+            "leases": [
+                {
+                    "status": {
+                        "forwarded_ports": {
+                            "node": [
+                                {"port": 1317, "host": "5.6.7.8", "externalPort": 31317},
+                                {"port": 26657, "host": "5.6.7.8", "externalPort": 32657},
+                            ]
+                        }
+                    }
+                }
+            ],
+        }
+        _run_cli(monkeypatch, ["just-akash", "status", "--json", "--dseq", "12345"])
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        endpoints = result["endpoints"]
+        lcd = next(e for e in endpoints if e["internal_port"] == 1317)
+        assert lcd["host"] == "5.6.7.8"
+        assert lcd["port"] == 31317
+
+
 class TestCliStatusNoDeployments:
     @patch("just_akash.api._resolve_dseq", return_value="")
     @patch("just_akash.api.AkashConsoleAPI")


### PR DESCRIPTION
## Summary
- add Digital Frontier maintenance and ownership note to the README
- update the clone URL to the Digital-Frontier-LDA repository
- **add a personal Akash LCD/RPC node deployment** — new `sdl/akash-node.yaml`
  and `Justfile` recipes (`up-akash-node`, `akash-node-lcd`, `down-akash-node`).
  This is executable behavior, not docs-only — assess operational impact.
- **CI**: run gitleaks via its (unlicensed) CLI instead of the org-license-gated
  action; serialize the two live E2E jobs so they no longer collide on a shared
  Akash account.
- address bot review: make `akash-node-lcd` actually emit the forwarded LCD URL
  (`status --json` now includes `endpoints`); default `AKASH_API_ENABLED_UNSAFE_CORS`
  to false; add the `started_at` log line to `down-akash-node`.

## Testing
- `uv run pytest` — 654 passing (added a regression test for the LCD endpoint)
- `uv run ruff check/format`, `uv run pyright` — clean
- live E2E (Akash deploy/lease) run in CI

----
## Summary by Gitar

- **Added Akash node deployment:**
  - Introduced `sdl/akash-node.yaml` to deploy an archival-ready Akash LCD/RPC node via `cosmos-omnibus`.
  - Added `Justfile` recipes `up-akash-node`, `akash-node-lcd`, and `down-akash-node` to manage the node lifecycle.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three deployment recipes to set up, monitor, and manage a personal Akash node with automated configuration, data persistence, and endpoint exposure for REST, gRPC, and RPC interfaces.

* **Documentation**
  * Updated repository ownership and setup instructions. Added comprehensive guide for deploying a personal Akash node, including endpoint details, bootstrap/snapshot configuration, and post-provisioning wallet validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
