### PR TITLE
fix: never select non-open bids — state filter + phase-2 grace cap + lease retry (#14)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -221,7 +225,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 186
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -339,5 +343,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T18:53:20Z"
+  "generated_at": "2026-06-10T21:16:29Z"
 }

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -50,6 +50,40 @@ def _fmt_price(bid) -> str:
     return f"{amount} {denom}"
 
 
+def _bid_state(b) -> str:
+    """Extract a bid's state, tolerating both flat and nested API shapes."""
+    if not isinstance(b, dict):
+        return "?"
+    nested = b.get("bid", {})
+    nested_state = nested.get("state", "?") if isinstance(nested, dict) else "?"
+    return b.get("state", nested_state)
+
+
+def _backup_fallback_grace_s() -> int:
+    """Max seconds after order creation to keep waiting for a preferred bid
+    while open BACKUP bids are available (issue #14). Akash bids expire
+    ~5 min after the order opens, so a grace longer than that guarantees the
+    fallback pool is stale by the time phase 3 runs. Override with
+    JUST_AKASH_BACKUP_FALLBACK_S.
+    """
+    try:
+        return int(os.environ.get("JUST_AKASH_BACKUP_FALLBACK_S", "240"))
+    except ValueError:
+        return 240
+
+
+def _is_open_bid(b) -> bool:
+    """Whether a bid is still leasable.
+
+    The Console API keeps returning bids after they expire (state flips away
+    from `open`), and leasing a non-open bid is a guaranteed HTTP 400
+    ("The selected bid is no longer open") — issue #14. Bids with no state
+    field at all ("?") are treated as open so older/partial API shapes keep
+    working.
+    """
+    return _bid_state(b) in ("open", "?")
+
+
 def _classify_bid(provider: str | None, preferred: list[str], backup: list[str]) -> str:
     """Tag a bid by tier. With no allowlist set, every bid is ACCEPTED.
     Accepts None (a malformed bid with no provider field) — classified as
@@ -82,8 +116,7 @@ def _log_bid_table(
             _log(logging.INFO, f"    [{i + 1}] (invalid bid entry)")
             continue
         provider = _extract_provider(b) or "unknown"
-        _nested = b.get("bid", {})
-        state = b.get("state", _nested.get("state", "?") if isinstance(_nested, dict) else "?")
+        state = _bid_state(b)
         suffix = ""
         if has_allowlist:
             suffix = f"  [{_classify_bid(provider, preferred, backup)}]"
@@ -278,17 +311,19 @@ def deploy(
     poll_count = 0
     last_bid_count = -1
 
+    def _has_open_tier_bid(current: list, tier: str) -> bool:
+        return any(
+            isinstance(b, dict)
+            and _is_open_bid(b)
+            and _classify_bid(_extract_provider(b) or "", preferred, backup) == tier
+            for b in current
+        )
+
     def _has_preferred_bid(current: list) -> bool:
-        for b in current:
-            if not isinstance(b, dict):
-                continue
-            p = _extract_provider(b) or ""
-            if _classify_bid(p, preferred, backup) == "PREFERRED":
-                return True
-        return False
+        return _has_open_tier_bid(current, "PREFERRED")
 
     def _has_any_valid_bid(current: list) -> bool:
-        return any(isinstance(b, dict) for b in current)
+        return any(isinstance(b, dict) and _is_open_bid(b) for b in current)
 
     def _do_poll() -> None:
         """Performs one poll, updates `bids`, prints progress + diff log line."""
@@ -323,9 +358,7 @@ def deploy(
                     if not isinstance(b, dict):
                         continue
                     p = _extract_provider(b) or "unknown"
-                    nested = b.get("bid", {})
-                    nested_state = nested.get("state", "?") if isinstance(nested, dict) else "?"
-                    s = b.get("state", nested_state)
+                    s = _bid_state(b)
                     tag = _classify_bid(p, preferred, backup)
                     _log(
                         logging.INFO,
@@ -360,12 +393,24 @@ def deploy(
     selection_phase = 0
 
     def _filter_tier(current: list, tier: str) -> list:
-        return [
-            b
-            for b in current
-            if isinstance(b, dict)
-            and _classify_bid(_extract_provider(b) or "", preferred, backup) == tier
-        ]
+        """Bids of a tier that are still leasable (state filter — issue #14)."""
+        pool = []
+        skipped_stale = 0
+        for b in current:
+            if not isinstance(b, dict):
+                continue
+            if _classify_bid(_extract_provider(b) or "", preferred, backup) != tier:
+                continue
+            if not _is_open_bid(b):
+                skipped_stale += 1
+                continue
+            pool.append(b)
+        if skipped_stale:
+            _log(
+                logging.WARNING,
+                f"  Skipped {skipped_stale} {tier} bid(s) no longer open (expired)",
+            )
+        return pool
 
     if has_allowlist:
         preferred_phase1 = _filter_tier(bids, "PREFERRED")
@@ -390,7 +435,35 @@ def deploy(
                 f"  Phase 2 ({label}): no preferred bid yet — "
                 f"waiting up to {bid_wait_retry}s for first preferred...",
             )
-            early_exit = _has_preferred_bid if has_allowlist else _has_any_valid_bid
+            if has_allowlist and backup:
+                # Akash bids expire ~5 min after the order opens. If the full
+                # grace outlasts that, phase 3 can only ever see stale backup
+                # bids (issue #14) — so once open backup bids exist, stop
+                # waiting for a preferred bid at the fallback safety mark.
+                fallback_after = start_time + _backup_fallback_grace_s()
+                fallback_cut = False
+
+                def _phase2_exit(current: list) -> bool:
+                    nonlocal fallback_cut
+                    if _has_preferred_bid(current):
+                        return True
+                    if time.time() >= fallback_after and _has_open_tier_bid(current, "BACKUP"):
+                        if not fallback_cut:
+                            fallback_cut = True
+                            _log(
+                                logging.WARNING,
+                                f"  Cutting preferred-grace short at "
+                                f"{int(time.time() - start_time)}s: open BACKUP bid(s) "
+                                f"available and bids expire ~5min after order creation",
+                            )
+                        return True
+                    return False
+
+                early_exit = _phase2_exit
+            elif has_allowlist:
+                early_exit = _has_preferred_bid
+            else:
+                early_exit = _has_any_valid_bid
             _poll_until(phase2_deadline, early_exit=early_exit)
             print()
 
@@ -598,23 +671,68 @@ def deploy(
         f"({phase_label[selection_phase]})",
     )
 
-    # Step 6: Create lease
+    # Step 6: Create lease (with stale-bid retry — issue #14).
+    # A bid can expire between selection and the lease POST (the Console API
+    # rejects it with 400 "no longer open"). On that specific failure,
+    # re-fetch bids and fall to the next cheapest open bid, tier order
+    # preserved (PREFERRED before BACKUP), before giving up.
+    def _next_open_bid(fresh: list, exclude: set[str]):
+        tiers = ["PREFERRED", "BACKUP"] if has_allowlist else ["ACCEPTED"]
+        for tier in tiers:
+            pool = [
+                b
+                for b in _filter_tier(fresh, tier)
+                if _extract_provider(b) and _extract_provider(b) not in exclude
+            ]
+            if pool:
+                return min(pool, key=lambda b: _extract_bid_price(b)[0])
+        return None
+
     _log(logging.INFO, "STEP 6: Creating lease...")
-    try:
-        lease_response = client.create_lease(
-            dseq=str(dseq),
-            provider=provider,
-            manifest=manifest,
-        )
-    except RuntimeError as e:
-        _log(logging.ERROR, f"Lease creation FAILED: {e}")
-        _log(logging.INFO, f"Cleaning up deployment {dseq}...")
+    max_lease_attempts = 3
+    failed_providers: set[str] = set()
+    lease_response = None
+    for attempt in range(1, max_lease_attempts + 1):
         try:
-            client.close_deployment(str(dseq))
-            _log(logging.INFO, f"Deployment {dseq} closed after lease failure")
-        except Exception as cleanup_err:
-            _log(logging.ERROR, f"Cleanup of deployment {dseq} also failed: {cleanup_err}")
-        raise RuntimeError(f"Failed to create lease: {e}") from e
+            lease_response = client.create_lease(
+                dseq=str(dseq),
+                provider=provider,
+                manifest=manifest,
+            )
+            break
+        except RuntimeError as e:
+            stale = "no longer open" in str(e).lower()
+            if stale and attempt < max_lease_attempts:
+                failed_providers.add(provider)
+                _log(
+                    logging.WARNING,
+                    f"Lease attempt {attempt}/{max_lease_attempts} hit a stale bid "
+                    f"(provider={provider}): re-fetching open bids...",
+                )
+                try:
+                    fresh_bids = client.get_bids(str(dseq))
+                except RuntimeError as poll_err:
+                    _log(logging.WARNING, f"  Bid re-fetch failed: {poll_err}")
+                    fresh_bids = []
+                next_bid = _next_open_bid(fresh_bids, failed_providers)
+                if next_bid is not None:
+                    provider = _extract_provider(next_bid) or ""
+                    price_amount, price_denom = _extract_bid_price(next_bid)
+                    _log(
+                        logging.INFO,
+                        f"  Retrying lease with next open bid: provider={provider}  "
+                        f"price={price_amount} {price_denom}",
+                    )
+                    continue
+                _log(logging.WARNING, "  No other open bid available to retry with")
+            _log(logging.ERROR, f"Lease creation FAILED: {e}")
+            _log(logging.INFO, f"Cleaning up deployment {dseq}...")
+            try:
+                client.close_deployment(str(dseq))
+                _log(logging.INFO, f"Deployment {dseq} closed after lease failure")
+            except Exception as cleanup_err:
+                _log(logging.ERROR, f"Cleanup of deployment {dseq} also failed: {cleanup_err}")
+            raise RuntimeError(f"Failed to create lease: {e}") from e
 
     _log(logging.INFO, "Lease created successfully!")
     _log(

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -567,6 +567,38 @@ def deploy(
             except Exception as cleanup_err:
                 _log(logging.ERROR, f"Cleanup of deployment {dseq} failed: {cleanup_err}")
             raise RuntimeError("No valid bids received — all bid entries were malformed.")
+        # Bids from our own providers exist, but every one has aged out of the
+        # 'open' state (issue #14). Without this branch the failure below would
+        # misreport it as "non-allowed providers", which misleads operators —
+        # the real cause is stale bids, not foreign ones.
+        if has_allowlist:
+            allowed_bids = [
+                b
+                for b in valid_bids
+                if _classify_bid(_extract_provider(b), preferred, backup) != "FOREIGN"
+            ]
+        else:
+            allowed_bids = valid_bids
+        if allowed_bids and not any(_is_open_bid(b) for b in allowed_bids):
+            states = sorted({_bid_state(b) for b in allowed_bids})
+            providers = [_extract_provider(b) or "unknown" for b in allowed_bids]
+            _log(
+                logging.ERROR,
+                f"All {len(allowed_bids)} bid(s) from your providers are no "
+                f"longer open (states seen: {states})",
+            )
+            _log(logging.ERROR, f"  Providers: {providers}")
+            _log(logging.INFO, f"Cleaning up deployment {dseq} (no open bids)...")
+            try:
+                client.close_deployment(str(dseq))
+                _log(logging.INFO, f"Deployment {dseq} closed after no open bids")
+            except Exception as cleanup_err:
+                _log(logging.ERROR, f"Cleanup of deployment {dseq} failed: {cleanup_err}")
+            raise RuntimeError(
+                f"Received {len(allowed_bids)} bid(s) from your providers but none "
+                f"are still open (states seen: {states}). Akash bids expire ~5 min "
+                "after the order opens — retry the deployment to solicit fresh bids."
+            )
         foreign = [_extract_provider(b) or "unknown" for b in bids]
         allowed_all = preferred + backup
         _log(logging.ERROR, f"All {len(bids)} bid(s) are from non-allowed providers")

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -408,7 +408,7 @@ def deploy(
         if skipped_stale:
             _log(
                 logging.WARNING,
-                f"  Skipped {skipped_stale} {tier} bid(s) no longer open (expired)",
+                f"  Skipped {skipped_stale} {tier} bid(s) not in 'open' state",
             )
         return pool
 

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -1,0 +1,239 @@
+"""Tests for issue #14 — stale (non-open) bids must never be selected/leased.
+
+Covers the three fix layers:
+1. `_bid_state` / `_is_open_bid` extraction and the state filter in selection.
+2. The phase-2 grace cut when open BACKUP bids are available.
+3. The lease-creation retry against the next open bid on a stale-bid 400.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from just_akash.deploy import (
+    _backup_fallback_grace_s,
+    _bid_state,
+    _is_open_bid,
+    deploy,
+)
+
+SDL_YAML = """
+version: "2.0"
+services:
+  web:
+    image: python:3.13-slim
+    expose:
+      - port: 22
+        as: 22
+        to:
+          - global: true
+"""
+
+
+def _make_bid(provider, amount, state="open", denom="uakt"):
+    return {
+        "id": {"provider": provider},
+        "price": {"amount": amount, "denom": denom},
+        "state": state,
+    }
+
+
+def _time_mock():
+    counter = [0.0]
+
+    def advance():
+        counter[0] += 1
+        return counter[0]
+
+    return advance
+
+
+def _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers=None, backup=None):
+    monkeypatch.setenv("AKASH_API_KEY", "test-key")
+    if providers is None:
+        monkeypatch.delenv("AKASH_PROVIDERS", raising=False)
+    else:
+        monkeypatch.setenv("AKASH_PROVIDERS", providers)
+    if backup is None:
+        monkeypatch.delenv("AKASH_PROVIDERS_BACKUP", raising=False)
+    else:
+        monkeypatch.setenv("AKASH_PROVIDERS_BACKUP", backup)
+    sdl_file = tmp_path / "sdl.yaml"
+    sdl_file.write_text(SDL_YAML)
+
+    client = MockAPI.return_value
+    client.create_deployment.return_value = {"dseq": "12345", "manifest": "abc"}
+    client.create_lease.return_value = {"lease": "ok"}
+
+    mock_time.time.side_effect = _time_mock()
+    mock_time.sleep.return_value = None
+    return client, str(sdl_file)
+
+
+class TestBidStateHelpers:
+    def test_flat_state(self):
+        assert _bid_state({"state": "open"}) == "open"
+        assert _bid_state({"state": "closed"}) == "closed"
+
+    def test_nested_state(self):
+        assert _bid_state({"bid": {"state": "open"}}) == "open"
+        assert _bid_state({"bid": {"state": "closed"}}) == "closed"
+
+    def test_flat_wins_over_nested(self):
+        assert _bid_state({"state": "closed", "bid": {"state": "open"}}) == "closed"
+
+    def test_missing_state(self):
+        assert _bid_state({"id": {"provider": "akash1a"}}) == "?"
+        assert _bid_state("not-a-dict") == "?"
+
+    def test_is_open(self):
+        assert _is_open_bid(_make_bid("akash1a", 10))
+        assert not _is_open_bid(_make_bid("akash1a", 10, state="closed"))
+        # No state field at all → assume open (older API shapes).
+        assert _is_open_bid({"id": {"provider": "akash1a"}})
+
+    def test_fallback_grace_env_override(self, monkeypatch):
+        monkeypatch.setenv("JUST_AKASH_BACKUP_FALLBACK_S", "99")
+        assert _backup_fallback_grace_s() == 99
+        monkeypatch.setenv("JUST_AKASH_BACKUP_FALLBACK_S", "not-a-number")
+        assert _backup_fallback_grace_s() == 240
+
+
+class TestSelectionSkipsStaleBids:
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_closed_cheaper_bid_loses_to_open_bid(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """Phase 1: a closed bid must not win even if it is the cheapest."""
+        client, sdl = _setup(
+            MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1cheap,akash1live"
+        )
+        client.get_bids.return_value = [
+            _make_bid("akash1cheap", 10, state="closed"),
+            _make_bid("akash1live", 50),
+        ]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert result["provider"] == "akash1live"
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_all_stale_bids_fail_selection(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """If every bid has expired, selection must fail — not lease a dead bid."""
+        client, sdl = _setup(
+            MockAPI,
+            mock_time,
+            tmp_path,
+            monkeypatch,
+            providers="akash1pref",
+            backup="akash1back",
+        )
+        client.get_bids.return_value = [
+            _make_bid("akash1back", 10, state="closed"),
+        ]
+
+        with pytest.raises(RuntimeError):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        client.create_lease.assert_not_called()
+
+
+class TestPhase2GraceCut:
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_grace_cut_short_when_backup_bid_open(
+        self, MockAPI, mock_time, tmp_path, monkeypatch, capsys
+    ):
+        """With no preferred bid and an open backup bid, phase 2 stops at the
+        fallback safety mark instead of burning the full grace window."""
+        monkeypatch.setenv("JUST_AKASH_BACKUP_FALLBACK_S", "10")
+        client, sdl = _setup(
+            MockAPI,
+            mock_time,
+            tmp_path,
+            monkeypatch,
+            providers="akash1pref",
+            backup="akash1back",
+        )
+        client.get_bids.return_value = [_make_bid("akash1back", 20)]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=500)
+        assert result["provider"] == "akash1back"
+        out = capsys.readouterr().out
+        assert "Cutting preferred-grace short" in out
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_full_grace_preserved_without_backup_bids(
+        self, MockAPI, mock_time, tmp_path, monkeypatch, capsys
+    ):
+        """No backup bid → the grace cut must not fire (full patience kept)."""
+        monkeypatch.setenv("JUST_AKASH_BACKUP_FALLBACK_S", "10")
+        client, sdl = _setup(
+            MockAPI,
+            mock_time,
+            tmp_path,
+            monkeypatch,
+            providers="akash1pref",
+            backup="akash1back",
+        )
+        client.get_bids.return_value = [_make_bid("akash1foreign", 20)]
+
+        with pytest.raises(RuntimeError):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=30)
+        out = capsys.readouterr().out
+        assert "Cutting preferred-grace short" not in out
+
+
+class TestLeaseStaleRetry:
+    STALE_ERR = RuntimeError(
+        "API Error (400): Failed to create lease: Cannot create lease: "
+        "The selected bid is no longer open. Please refresh and select an available bid."
+    )
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_retries_next_open_bid_on_stale_400(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """First lease POST hits a stale bid → re-fetch → lease the next open bid."""
+        client, sdl = _setup(
+            MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a,akash1b"
+        )
+        client.get_bids.return_value = [
+            _make_bid("akash1a", 10),
+            _make_bid("akash1b", 20),
+        ]
+        client.create_lease.side_effect = [self.STALE_ERR, {"lease": "ok"}]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert result["provider"] == "akash1b"
+        assert client.create_lease.call_count == 2
+        client.close_deployment.assert_not_called()
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_gives_up_when_no_other_open_bid(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """Stale 400 with no remaining open bid → cleanup + raise (old behavior)."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = self.STALE_ERR
+
+        with pytest.raises(RuntimeError, match="Failed to create lease"):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert client.create_lease.call_count == 1
+        client.close_deployment.assert_called_once_with("12345")
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_non_stale_lease_error_does_not_retry(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """Other lease errors keep the original fail-fast + cleanup behavior."""
+        client, sdl = _setup(
+            MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a,akash1b"
+        )
+        client.get_bids.return_value = [
+            _make_bid("akash1a", 10),
+            _make_bid("akash1b", 20),
+        ]
+        client.create_lease.side_effect = RuntimeError("API Error (500): provider exploded")
+
+        with pytest.raises(RuntimeError, match="Failed to create lease"):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert client.create_lease.call_count == 1
+        client.close_deployment.assert_called_once_with("12345")

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -131,8 +131,26 @@ class TestSelectionSkipsStaleBids:
             _make_bid("akash1back", 10, state="closed"),
         ]
 
-        with pytest.raises(RuntimeError):
+        # The bid is from an ALLOWED provider, just stale — the failure must say
+        # "none are still open", not misattribute it to non-allowed providers.
+        with pytest.raises(RuntimeError, match="none are still open") as exc:
             deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert "NONE from our providers" not in str(exc.value)
+        client.create_lease.assert_not_called()
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_all_stale_bids_no_allowlist(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """With no allowlist, an all-stale bid pool still reports 'no open bids'
+        rather than falling through to the non-allowed-providers message."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch)
+        client.get_bids.return_value = [
+            _make_bid("akash1any", 10, state="closed"),
+        ]
+
+        with pytest.raises(RuntimeError, match="none are still open") as exc:
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        assert "NONE from our providers" not in str(exc.value)
         client.create_lease.assert_not_called()
 
 


### PR DESCRIPTION
Fixes #14.

## Problem

`deploy()` could select a bid whose on-chain state was no longer `open`, producing a guaranteed `HTTP 400 — "Cannot create lease: The selected bid is no longer open"`. Phase-3 backup fallback was *structurally* broken: it can only fire after phase 1 + phase 2 (commonly 120s + 480s = 10 min), but Akash bids expire ~5 min after the order opens — so the fallback pool was always stale exactly in the scenario backups exist for (quiet preferred tier). Seen in production: Blazing CI run 27282027491 (full log excerpt in #14).

## Fix (three layers)

1. **State filter at every selection point.** New `_bid_state()` / `_is_open_bid()` helpers (mirroring the nested-shape extraction the log helper already used); `_filter_tier()`, `_has_preferred_bid()`, `_has_any_valid_bid()` now skip non-open bids. Skipped bids are logged (`Skipped N BACKUP bid(s) no longer open`) so operators see why a visible bid wasn't picked. Bids with no `state` field are treated as open, keeping older/partial API shapes working.

2. **Phase-2 grace cap while backup bids are open.** Once open BACKUP bids exist and `JUST_AKASH_BACKUP_FALLBACK_S` (default 240s) has elapsed since order creation, phase 2 stops waiting for a preferred bid so phase 3 can lease the backup bid *before it expires*. The full grace window is preserved when there are no backup bids to fall back to (today's behavior), and a preferred bid arriving any time before the cut still wins instantly.

3. **Lease stale-bid retry.** If `POST /v1/leases` still hits "no longer open" (bid expired between selection and POST), re-fetch bids and retry with the next cheapest open bid — tier order preserved (PREFERRED before BACKUP), already-failed providers excluded, max 3 attempts — before falling back to the original cleanup-and-raise. Non-stale lease errors keep the original fail-fast behavior.

Happy path is unchanged: a phase-1 selection happens seconds after the preferred bid appears, far inside TTL, and the retry loop body never runs unless the 400 occurs.

## Tests

`tests/test_stale_bid_selection.py` — 13 new tests:
- `_bid_state` flat/nested/missing shapes; `_is_open_bid` incl. missing-state tolerance; env override parsing.
- Selection: cheapest-but-closed bid loses to a pricier open bid; all-stale pool fails selection without ever calling `create_lease`.
- Grace cut: fires with an open backup bid + silent preferred (asserts the log line and phase-3 result); does **not** fire when no backup bid exists.
- Lease retry: stale 400 → re-fetch → next open bid leased (no deployment close); no alternative open bid → cleanup + raise; non-stale error → no retry, original behavior.

Full suite: **595 passed** (was 582), `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry lease creation up to 3 times on stale-bid failure, automatically selecting the next available open provider.
  * Configurable grace window that time-limits waiting for preferred providers before falling back to backups.

* **Bug Fixes**
  * Stronger bid-state handling to avoid selecting expired/closed bids and to treat unknown/missing state as open where appropriate.
  * Phase-2 selection now respects open-bid availability when deciding early exit.

* **Tests**
  * Added tests covering stale-bid filtering, grace-cut behavior, and lease-retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->