### PR TITLE
fix: retry the same bid on transient Console 400 'JWT has invalid claims'

### DIFF
--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -736,12 +736,12 @@ def deploy(
             err_str = str(e).lower()
             stale = "no longer open" in err_str
             # Console API intermittently rejects lease creation with
-            # 400 "JWT has invalid claims" (~35-44s latency, then the 400) —
-            # observed 2026-06-11 flapping ~50% per attempt against the same
-            # bid that leased fine minutes before/after (Blazing CI runs
-            # 27360752029/27360753233/27361360403). The bid itself is healthy,
-            # so retry the SAME provider after a short backoff instead of
-            # advancing to the next bid.
+            # 400 "JWT has invalid claims" while the bid itself is healthy
+            # (transient auth flap on the Console side — see issue #18).
+            # Retry the SAME provider after a short backoff instead of
+            # advancing to the next bid. Message-match is intentional: the
+            # structured fields are generic (code=bad_request,
+            # type=client_error), so the message is the only signal.
             transient_auth = "jwt has invalid claims" in err_str
             if transient_auth and attempt < max_lease_attempts:
                 _log(

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -733,7 +733,25 @@ def deploy(
             )
             break
         except RuntimeError as e:
-            stale = "no longer open" in str(e).lower()
+            err_str = str(e).lower()
+            stale = "no longer open" in err_str
+            # Console API intermittently rejects lease creation with
+            # 400 "JWT has invalid claims" (~35-44s latency, then the 400) —
+            # observed 2026-06-11 flapping ~50% per attempt against the same
+            # bid that leased fine minutes before/after (Blazing CI runs
+            # 27360752029/27360753233/27361360403). The bid itself is healthy,
+            # so retry the SAME provider after a short backoff instead of
+            # advancing to the next bid.
+            transient_auth = "jwt has invalid claims" in err_str
+            if transient_auth and attempt < max_lease_attempts:
+                _log(
+                    logging.WARNING,
+                    f"Lease attempt {attempt}/{max_lease_attempts} hit a transient "
+                    f"Console auth error (JWT claims) for provider={provider} — "
+                    "retrying the same bid in 15s...",
+                )
+                time.sleep(15)
+                continue
             if stale and attempt < max_lease_attempts:
                 failed_providers.add(provider)
                 _log(

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -255,3 +255,43 @@ class TestLeaseStaleRetry:
             deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
         assert client.create_lease.call_count == 1
         client.close_deployment.assert_called_once_with("12345")
+
+
+class TestLeaseTransientJWTRetry:
+    """Console API intermittently 400s lease creation with "JWT has invalid
+    claims" while the bid itself is healthy (observed 2026-06-11, ~50%
+    flap rate against the same provider). Retry the SAME bid after a
+    backoff — do NOT advance to the next provider."""
+
+    JWT_ERR = RuntimeError("API Error (400): JWT has invalid claims")
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_retries_same_bid_on_jwt_claims_400(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        client, sdl = _setup(
+            MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a,akash1b"
+        )
+        client.get_bids.return_value = [
+            _make_bid("akash1a", 10),
+            _make_bid("akash1b", 20),
+        ]
+        client.create_lease.side_effect = [self.JWT_ERR, {"lease": "ok"}]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        # Same provider on the retry — the bid was never the problem.
+        assert result["provider"] == "akash1a"
+        assert client.create_lease.call_count == 2
+        client.close_deployment.assert_not_called()
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_gives_up_after_max_attempts(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = self.JWT_ERR
+
+        with pytest.raises(RuntimeError, match="Failed to create lease"):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+        # 3 attempts, all on the same (only) provider, then cleanup.
+        assert client.create_lease.call_count == 3
+        client.close_deployment.assert_called_once_with("12345")


### PR DESCRIPTION
The Console API intermittently rejects lease creation with `400 JWT has invalid claims` (~35-44s latency before the 400), flapping ~50% per attempt against a bid that leases fine minutes before/after — observed 2026-06-11 across Blazing CI runs 27360752029 / 27360753233 / 27361360403 (4 failures, 2 successes, all against the same healthy bid; it was the only open bid at the time, so every flap killed the whole provision).

Unlike the stale-bid 400 (#14/#15), the bid itself is healthy — so this retries the **same provider** after a 15s backoff, within the existing `max_lease_attempts` budget, instead of advancing to the next bid. Other lease errors keep the fail-fast + cleanup behavior.

2 new tests (same-bid retry; give-up after max attempts with cleanup); 670/670 suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lease-creation error handling for transient authentication failures (e.g., JWT claim errors). The system now pauses and retries the same provider bid a few times before moving on, reducing unnecessary provider switching and improving deployment resilience.

* **Tests**
  * Added tests validating retry behavior for transient auth failures and proper cleanup when retries are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->