### PR TITLE
fix: re-create the order when every bid is stale at lease time

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 272
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T10:54:33Z"
+  "generated_at": "2026-06-22T13:42:46Z"
 }

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -73,6 +73,30 @@ def _backup_fallback_grace_s() -> int:
         return 240
 
 
+def _redeploy_poll_window() -> tuple[float, float, float]:
+    """Fast-poll window for the issue-#19 re-deploy round: (total_wait,
+    backup_courtesy, poll_interval) in seconds.
+
+    Intentionally short — the phased patience of the normal selection path is
+    exactly what aged the first round's bid past its ~5-min expiry, so the
+    re-created order is leased aggressively (preferred wins instantly; backup
+    only after the courtesy window). Override via JUST_AKASH_REDEPLOY_WAIT_S /
+    _BACKUP_COURTESY_S / _POLL_INTERVAL_S.
+    """
+
+    def _f(name: str, default: str) -> float:
+        try:
+            return float(os.environ.get(name, default))
+        except ValueError:
+            return float(default)
+
+    return (
+        _f("JUST_AKASH_REDEPLOY_WAIT_S", "75"),
+        _f("JUST_AKASH_REDEPLOY_BACKUP_COURTESY_S", "20"),
+        _f("JUST_AKASH_REDEPLOY_POLL_INTERVAL_S", "5"),
+    )
+
+
 def _is_open_bid(b) -> bool:
     """Whether a bid is still leasable.
 
@@ -751,6 +775,90 @@ def deploy(
                 return min(pool, key=lambda b: _extract_bid_price(b)[0])
         return None
 
+    def _poll_fresh_bid(order_dseq: str, wait_s: float, courtesy_s: float, interval_s: float):
+        """Poll a freshly re-created order for the cheapest OPEN bid, tier-first.
+
+        Preferred (or ACCEPTED when no allowlist) wins immediately; BACKUP is
+        accepted only after ``courtesy_s``. Returns the bid dict, or None if
+        nothing eligible appears within ``wait_s``. Reuses ``_filter_tier`` so
+        only open bids are ever considered.
+        """
+        first_tier = "PREFERRED" if has_allowlist else "ACCEPTED"
+        start = time.time()
+        while time.time() - start < wait_s:
+            try:
+                current = client.get_bids(str(order_dseq))
+            except RuntimeError:
+                current = []
+            pool = _filter_tier(current, first_tier)
+            if pool:
+                return min(pool, key=lambda b: _extract_bid_price(b)[0])
+            if has_allowlist and time.time() - start >= courtesy_s:
+                backup_pool = _filter_tier(current, "BACKUP")
+                if backup_pool:
+                    return min(backup_pool, key=lambda b: _extract_bid_price(b)[0])
+            time.sleep(interval_s)
+        return None
+
+    def _redeploy_and_reselect() -> tuple[str, str, str, float, str]:
+        """Close the stale order and create a fresh one (issue #19), then select
+        a fresh open bid on it.
+
+        Returns ``(dseq, manifest, provider, price_amount, price_denom)`` for the
+        re-created order. Raises RuntimeError with an accurate cause if the round
+        fails; any newly-created order is cleaned up before raising.
+        """
+        _log(
+            logging.WARNING,
+            f"All bids on order {dseq} are stale — re-creating the order for "
+            "fresh bids (1 re-deploy round)...",
+        )
+        try:
+            client.close_deployment(str(dseq))
+            _log(logging.INFO, f"  Stale order {dseq} closed")
+        except Exception as close_err:
+            # Proceed so the deploy can still succeed, but surface the leak
+            # loudly and actionably — the old escrow stays locked until closed.
+            _log(
+                logging.WARNING,
+                f"  WARNING: could not close stale order {dseq} ({close_err}). "
+                f"Its escrow stays locked until you close it: "
+                f"just-akash destroy --dseq {dseq}",
+            )
+        try:
+            redeploy_response = client.create_deployment(sdl_content, deposit=deposit)
+        except RuntimeError as redeploy_err:
+            raise RuntimeError(f"re-deploy create failed: {redeploy_err}") from redeploy_err
+        new_dseq = redeploy_response.get("dseq")
+        if new_dseq is None:
+            raise RuntimeError(
+                f"re-deploy returned no DSEQ (response: "
+                f"{json.dumps(redeploy_response, default=str)[:200]})"
+            )
+        _raw_manifest = redeploy_response.get("manifest", "")
+        new_manifest = _raw_manifest if isinstance(_raw_manifest, str) else ""
+        _log(
+            logging.INFO,
+            f"  Re-deployed: new order DSEQ={new_dseq} — fast-polling for fresh bids...",
+        )
+        wait_s, courtesy_s, interval_s = _redeploy_poll_window()
+        fresh = _poll_fresh_bid(str(new_dseq), wait_s, courtesy_s, interval_s)
+        fresh_provider = _extract_provider(fresh) if fresh is not None else None
+        if fresh is None or not fresh_provider:
+            try:
+                client.close_deployment(str(new_dseq))
+                _log(logging.INFO, f"  Re-created order {new_dseq} closed (no fresh bid)")
+            except Exception as cleanup_err:
+                _log(logging.ERROR, f"  Cleanup of {new_dseq} failed: {cleanup_err}")
+            raise RuntimeError(f"no fresh open bid on re-created order {new_dseq}")
+        amount, denom = _extract_bid_price(fresh)
+        _log(
+            logging.INFO,
+            f"  Fresh bid selected: provider={fresh_provider}  price={amount} {denom} "
+            "— leasing immediately",
+        )
+        return str(new_dseq), new_manifest, fresh_provider, amount, denom
+
     _log(logging.INFO, "STEP 6: Creating lease...")
     max_lease_attempts = 3
     failed_providers: set[str] = set()
@@ -823,84 +931,18 @@ def deploy(
                     continue
                 _log(logging.WARNING, "  No other open bid available to retry with")
             if stale and not redeployed:
-                # issue #19: every bid on this order is gone — re-create the
-                # order once and lease a fresh bid immediately.
+                # issue #19: every bid on this order has expired (bids share the
+                # ORDER's ~5-min clock, so re-fetching the same order can't
+                # recover). Close it, re-create once, and lease a fresh bid.
                 redeployed = True
                 attempt = 0
                 failed_providers.clear()
-                _log(
-                    logging.WARNING,
-                    f"All bids on order {dseq} are stale — re-creating the order "
-                    "for fresh bids (1 re-deploy round)...",
-                )
                 try:
-                    client.close_deployment(str(dseq))
-                    _log(logging.INFO, f"  Stale order {dseq} closed")
-                except Exception as close_err:
-                    _log(
-                        logging.WARNING,
-                        f"  Close of stale order {dseq} failed (continuing): {close_err}",
-                    )
-                try:
-                    redeploy_response = client.create_deployment(sdl_content)
+                    dseq, manifest, provider, price_amount, price_denom = _redeploy_and_reselect()
                 except RuntimeError as redeploy_err:
-                    _log(logging.ERROR, f"  Re-deploy failed: {redeploy_err}")
-                    raise RuntimeError(f"Failed to create lease: {e}") from e
-                new_dseq = redeploy_response.get("dseq")
-                _new_manifest_raw = redeploy_response.get("manifest", "")
-                if new_dseq is None:
-                    _log(logging.ERROR, "  Re-deploy returned no DSEQ")
-                    raise RuntimeError(f"Failed to create lease: {e}") from e
-                dseq = new_dseq
-                manifest = _new_manifest_raw if isinstance(_new_manifest_raw, str) else ""
-                _log(
-                    logging.INFO,
-                    f"  Re-deployed: new order DSEQ={dseq} — fast-polling for fresh bids...",
-                )
-                # Fast selection: preferred wins instantly; backup accepted
-                # after a short courtesy window. No phase-2 grace — aging the
-                # bid is exactly what killed round 1.
-                fresh_selected = None
-                _fp_start = time.time()
-                _fp_wait = 75.0
-                _fp_courtesy = 20.0
-                while time.time() - _fp_start < _fp_wait:
-                    try:
-                        current = client.get_bids(str(dseq))
-                    except RuntimeError:
-                        current = []
-                    first_tier = "PREFERRED" if has_allowlist else "ACCEPTED"
-                    pool = _filter_tier(current, first_tier)
-                    if pool:
-                        fresh_selected = min(pool, key=lambda b: _extract_bid_price(b)[0])
-                        break
-                    if has_allowlist and time.time() - _fp_start >= _fp_courtesy:
-                        backup_pool = _filter_tier(current, "BACKUP")
-                        if backup_pool:
-                            fresh_selected = min(
-                                backup_pool, key=lambda b: _extract_bid_price(b)[0]
-                            )
-                            break
-                    time.sleep(5)
-                if fresh_selected is None or not _extract_provider(fresh_selected):
-                    _log(logging.ERROR, "  No fresh open bid on the re-created order")
-                    _log(logging.INFO, f"Cleaning up deployment {dseq}...")
-                    try:
-                        client.close_deployment(str(dseq))
-                        _log(logging.INFO, f"Deployment {dseq} closed after lease failure")
-                    except Exception as cleanup_err:
-                        _log(
-                            logging.ERROR,
-                            f"Cleanup of deployment {dseq} also failed: {cleanup_err}",
-                        )
-                    raise RuntimeError(f"Failed to create lease: {e}") from e
-                provider = _extract_provider(fresh_selected) or ""
-                price_amount, price_denom = _extract_bid_price(fresh_selected)
-                _log(
-                    logging.INFO,
-                    f"  Fresh bid selected: provider={provider}  "
-                    f"price={price_amount} {price_denom} — leasing immediately",
-                )
+                    raise RuntimeError(
+                        f"Failed to create lease after re-deploy: {redeploy_err}"
+                    ) from redeploy_err
                 continue
             _log(logging.ERROR, f"Lease creation FAILED: {e}")
             _log(logging.INFO, f"Cleaning up deployment {dseq}...")

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -755,7 +755,20 @@ def deploy(
     max_lease_attempts = 3
     failed_providers: set[str] = set()
     lease_response = None
-    for attempt in range(1, max_lease_attempts + 1):
+    # issue #19: one bounded re-deploy round. By the time a backup-only
+    # market reaches lease creation, the selected bid is already
+    # ~JUST_AKASH_BACKUP_FALLBACK_S old (bids expire ~5 min after the ORDER
+    # opens), so a single Console flap (e.g. the ~35s 'JWT has invalid
+    # claims' 400 — issue #18) can age the only bid past expiry. Re-fetching
+    # bids on the SAME order then finds nothing open — every bid shares the
+    # order's clock. Only a NEW order gets fresh bids, so when the stale-bid
+    # retry runs out of open bids: close the order, re-create it, and lease
+    # the first open allowlisted bid IMMEDIATELY (no phased patience — that
+    # patience is what aged the first round past expiry).
+    redeployed = False
+    attempt = 0
+    while True:
+        attempt += 1
         try:
             lease_response = client.create_lease(
                 dseq=str(dseq),
@@ -773,15 +786,18 @@ def deploy(
             # advancing to the next bid. Message-match is intentional: the
             # structured fields are generic (code=bad_request,
             # type=client_error), so the message is the only signal.
+            # 5s backoff (was 15s): the failing request itself burns ~35s,
+            # and every second of backoff ages the bid toward its ~5-min
+            # expiry (issue #19).
             transient_auth = "jwt has invalid claims" in err_str
             if transient_auth and attempt < max_lease_attempts:
                 _log(
                     logging.WARNING,
                     f"Lease attempt {attempt}/{max_lease_attempts} hit a transient "
                     f"Console auth error (JWT claims) for provider={provider} — "
-                    "retrying the same bid in 15s...",
+                    "retrying the same bid in 5s...",
                 )
-                time.sleep(15)
+                time.sleep(5)
                 continue
             if stale and attempt < max_lease_attempts:
                 failed_providers.add(provider)
@@ -806,6 +822,86 @@ def deploy(
                     )
                     continue
                 _log(logging.WARNING, "  No other open bid available to retry with")
+            if stale and not redeployed:
+                # issue #19: every bid on this order is gone — re-create the
+                # order once and lease a fresh bid immediately.
+                redeployed = True
+                attempt = 0
+                failed_providers.clear()
+                _log(
+                    logging.WARNING,
+                    f"All bids on order {dseq} are stale — re-creating the order "
+                    "for fresh bids (1 re-deploy round)...",
+                )
+                try:
+                    client.close_deployment(str(dseq))
+                    _log(logging.INFO, f"  Stale order {dseq} closed")
+                except Exception as close_err:
+                    _log(
+                        logging.WARNING,
+                        f"  Close of stale order {dseq} failed (continuing): {close_err}",
+                    )
+                try:
+                    redeploy_response = client.create_deployment(sdl_content)
+                except RuntimeError as redeploy_err:
+                    _log(logging.ERROR, f"  Re-deploy failed: {redeploy_err}")
+                    raise RuntimeError(f"Failed to create lease: {e}") from e
+                new_dseq = redeploy_response.get("dseq")
+                _new_manifest_raw = redeploy_response.get("manifest", "")
+                if new_dseq is None:
+                    _log(logging.ERROR, "  Re-deploy returned no DSEQ")
+                    raise RuntimeError(f"Failed to create lease: {e}") from e
+                dseq = new_dseq
+                manifest = _new_manifest_raw if isinstance(_new_manifest_raw, str) else ""
+                _log(
+                    logging.INFO,
+                    f"  Re-deployed: new order DSEQ={dseq} — fast-polling for fresh bids...",
+                )
+                # Fast selection: preferred wins instantly; backup accepted
+                # after a short courtesy window. No phase-2 grace — aging the
+                # bid is exactly what killed round 1.
+                fresh_selected = None
+                _fp_start = time.time()
+                _fp_wait = 75.0
+                _fp_courtesy = 20.0
+                while time.time() - _fp_start < _fp_wait:
+                    try:
+                        current = client.get_bids(str(dseq))
+                    except RuntimeError:
+                        current = []
+                    first_tier = "PREFERRED" if has_allowlist else "ACCEPTED"
+                    pool = _filter_tier(current, first_tier)
+                    if pool:
+                        fresh_selected = min(pool, key=lambda b: _extract_bid_price(b)[0])
+                        break
+                    if has_allowlist and time.time() - _fp_start >= _fp_courtesy:
+                        backup_pool = _filter_tier(current, "BACKUP")
+                        if backup_pool:
+                            fresh_selected = min(
+                                backup_pool, key=lambda b: _extract_bid_price(b)[0]
+                            )
+                            break
+                    time.sleep(5)
+                if fresh_selected is None or not _extract_provider(fresh_selected):
+                    _log(logging.ERROR, "  No fresh open bid on the re-created order")
+                    _log(logging.INFO, f"Cleaning up deployment {dseq}...")
+                    try:
+                        client.close_deployment(str(dseq))
+                        _log(logging.INFO, f"Deployment {dseq} closed after lease failure")
+                    except Exception as cleanup_err:
+                        _log(
+                            logging.ERROR,
+                            f"Cleanup of deployment {dseq} also failed: {cleanup_err}",
+                        )
+                    raise RuntimeError(f"Failed to create lease: {e}") from e
+                provider = _extract_provider(fresh_selected) or ""
+                price_amount, price_denom = _extract_bid_price(fresh_selected)
+                _log(
+                    logging.INFO,
+                    f"  Fresh bid selected: provider={provider}  "
+                    f"price={price_amount} {price_denom} — leasing immediately",
+                )
+                continue
             _log(logging.ERROR, f"Lease creation FAILED: {e}")
             _log(logging.INFO, f"Cleaning up deployment {dseq}...")
             try:

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -80,8 +80,8 @@ def _redeploy_poll_window() -> tuple[float, float, float]:
     Intentionally short — the phased patience of the normal selection path is
     exactly what aged the first round's bid past its ~5-min expiry, so the
     re-created order is leased aggressively (preferred wins instantly; backup
-    only after the courtesy window). Override via JUST_AKASH_REDEPLOY_WAIT_S /
-    _BACKUP_COURTESY_S / _POLL_INTERVAL_S.
+    only after the courtesy window). Override via JUST_AKASH_REDEPLOY_WAIT_S,
+    JUST_AKASH_REDEPLOY_BACKUP_COURTESY_S, and JUST_AKASH_REDEPLOY_POLL_INTERVAL_S.
     """
 
     def _f(name: str, default: str) -> float:

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -228,15 +228,69 @@ class TestLeaseStaleRetry:
     @patch("just_akash.deploy.time")
     @patch("just_akash.deploy.AkashConsoleAPI")
     def test_gives_up_when_no_other_open_bid(self, MockAPI, mock_time, tmp_path, monkeypatch):
-        """Stale 400 with no remaining open bid → cleanup + raise (old behavior)."""
+        """Stale 400 with no remaining open bid → ONE re-deploy round
+        (issue #19), and when the fresh order's lease is stale too → cleanup
+        + raise."""
         client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
         client.get_bids.return_value = [_make_bid("akash1a", 10)]
         client.create_lease.side_effect = self.STALE_ERR
 
         with pytest.raises(RuntimeError, match="Failed to create lease"):
             deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
-        assert client.create_lease.call_count == 1
-        client.close_deployment.assert_called_once_with("12345")
+        # 1 lease attempt on the original order + 1 on the re-created order.
+        assert client.create_lease.call_count == 2
+        # Closed twice: the stale order at re-deploy, the new order at failure.
+        assert client.close_deployment.call_count == 2
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploys_once_when_all_bids_stale(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """issue #19: every bid on the order expired (bids share the ORDER's
+        ~5-min clock) → close the order, re-create it, lease a fresh bid
+        immediately. Re-fetching bids on the same order can never recover."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = [self.STALE_ERR, {"lease": "ok"}]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        assert result["dseq"] == "222"
+        assert result["provider"] == "akash1a"
+        assert client.create_lease.call_count == 2
+        # Round 2 leases against the NEW order with the NEW manifest.
+        _, round2_kwargs = client.create_lease.call_args
+        assert round2_kwargs["dseq"] == "222"
+        assert round2_kwargs["manifest"] == "m2"
+        # Only the stale order was closed.
+        client.close_deployment.assert_called_once_with("111")
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_jwt_flap_then_stale_redeploys(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """The production failure chain (blazing run 27431505470): a slow
+        'JWT has invalid claims' 400 ages the only bid past expiry, the
+        retry hits 'no longer open' → re-deploy once → fresh bid leases."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = [
+            TestLeaseTransientJWTRetry.JWT_ERR,
+            self.STALE_ERR,
+            {"lease": "ok"},
+        ]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        assert result["dseq"] == "222"
+        assert client.create_lease.call_count == 3
+        client.close_deployment.assert_called_once_with("111")
 
     @patch("just_akash.deploy.time")
     @patch("just_akash.deploy.AkashConsoleAPI")

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -310,6 +310,80 @@ class TestLeaseStaleRetry:
         assert client.create_lease.call_count == 1
         client.close_deployment.assert_called_once_with("12345")
 
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploy_preserves_deposit(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """The re-created order must be funded with the SAME --deposit as the
+        original (issue #19 follow-up); otherwise re-deploy silently falls back
+        to the default escrow."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = [self.STALE_ERR, {"lease": "ok"}]
+
+        deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5, deposit=12.0)
+
+        assert client.create_deployment.call_count == 2
+        # Both the original order and the re-deploy use the same deposit.
+        for call in client.create_deployment.call_args_list:
+            assert call.kwargs.get("deposit") == 12.0
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploy_no_fresh_bid_cleans_up_and_raises(
+        self, MockAPI, mock_time, tmp_path, monkeypatch
+    ):
+        """If the re-created order never yields an open allowlisted bid, the
+        fast-poll times out → the new order is cleaned up and the failure is
+        surfaced with an accurate cause."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        # Order 111 has a bid (drives selection + the stale lease); the
+        # re-created order 222 yields nothing.
+        client.get_bids.side_effect = lambda d: [_make_bid("akash1a", 10)] if d == "111" else []
+        client.create_lease.side_effect = self.STALE_ERR
+
+        with pytest.raises(RuntimeError, match="no fresh open bid on re-created order 222"):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        assert client.create_lease.call_count == 1  # round 2 never reached
+        # Closed twice: stale order 111 at re-deploy, new order 222 on timeout.
+        assert client.close_deployment.call_count == 2
+        assert client.close_deployment.call_args_list[0].args == ("111",)
+        assert client.close_deployment.call_args_list[1].args == ("222",)
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploy_proceeds_when_close_of_stale_order_fails(
+        self, MockAPI, mock_time, tmp_path, monkeypatch, capsys
+    ):
+        """If closing the stale order fails, re-deploy still proceeds (so the
+        deploy can succeed) but warns loudly with an actionable remediation —
+        the old escrow stays locked until manually closed."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = [self.STALE_ERR, {"lease": "ok"}]
+        client.close_deployment.side_effect = RuntimeError("close exploded")
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        assert result["dseq"] == "222"
+        # Only the stale order's close was attempted (and it failed); the new
+        # order succeeded so no cleanup-close happened.
+        client.close_deployment.assert_called_once_with("111")
+        out = capsys.readouterr().out
+        assert "just-akash destroy --dseq 111" in out
+
 
 class TestLeaseTransientJWTRetry:
     """Console API intermittently 400s lease creation with "JWT has invalid

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -232,6 +232,12 @@ class TestLeaseStaleRetry:
         (issue #19), and when the fresh order's lease is stale too → cleanup
         + raise."""
         client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        # Distinct dseqs for the original vs re-created order, so the close
+        # assertions are unambiguous about which order was torn down when.
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
         client.get_bids.return_value = [_make_bid("akash1a", 10)]
         client.create_lease.side_effect = self.STALE_ERR
 
@@ -239,8 +245,11 @@ class TestLeaseStaleRetry:
             deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
         # 1 lease attempt on the original order + 1 on the re-created order.
         assert client.create_lease.call_count == 2
-        # Closed twice: the stale order at re-deploy, the new order at failure.
+        # Closed twice: the stale order (111) at re-deploy, the new order (222)
+        # when its lease is stale too.
         assert client.close_deployment.call_count == 2
+        assert client.close_deployment.call_args_list[0].args == ("111",)
+        assert client.close_deployment.call_args_list[1].args == ("222",)
 
     @patch("just_akash.deploy.time")
     @patch("just_akash.deploy.AkashConsoleAPI")


### PR DESCRIPTION
Closes #19.

## Problem
Bids expire ~5 min after the **order** opens. A backup-only market already burns ~`JUST_AKASH_BACKUP_FALLBACK_S` (240s) of that on phased patience, so one slow Console flap at lease time — the ~35s `JWT has invalid claims` 400 (#18) plus the 15s retry backoff — ages the only bid past expiry. The #14 re-fetch then finds nothing open, **and never can**: every bid shares the order's clock. Observed twice consecutively on blazing CI (runs 27429061105, 27431505470), exact chain in #19.

## Fix
- When the stale-bid retry has no open bid left: close the order, re-create it (same SDL), and lease the first open allowlisted bid **immediately** — preferred wins instantly, backup after a 20s courtesy window, no phase-2 grace (that patience is what aged round 1 past expiry). One bounded re-deploy round, then the existing cleanup+raise.
- JWT-claims retry backoff 15s → 5s: the failing request itself burns ~35s; every backoff second ages the bid toward expiry.

## Tests
672 passed. Updated the no-other-open-bid contract test (now: one re-deploy round, then give up) and added:
- `test_redeploys_once_when_all_bids_stale` — happy path, asserts round 2 leases the **new** DSEQ/manifest and only the stale order is closed
- `test_jwt_flap_then_stale_redeploys` — the production failure chain end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved deployment retry behavior for transient authentication failures by using a shorter backoff window, speeding up recovery.
  * When a chosen bid becomes stale, deployment now performs exactly one bounded redeploy to find a fresh open allowlisted bid and continues leasing automatically; if none is found, it fails cleanly and cleans up the relevant orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->