### PR TITLE
feat: full Console API lifecycle coverage (update/logs/events/add-funds/auto-topup)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,17 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -54,17 +54,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,69 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly (Mon 06:00 UTC) so newly-disclosed dependency CVEs surface even
+    # without a code change.
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # Mirrors `just semgrep`. Two rules inherent to a remote-exec CLI are
+      # excluded (documented in SECURITY.md / Justfile); subprocess-shell-true
+      # and all other rules stay active. --error fails the build on any finding.
+      - name: Semgrep scan
+        run: |
+          uvx semgrep scan \
+            --config p/python --config p/security-audit \
+            --exclude-rule python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args \
+            --exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
+            --error --metrics off just_akash/
+
+  dependency-audit:
+    name: Dependency CVE audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      # Mirrors `just audit`. Audits the synced environment against the PyPI
+      # advisory database. Fails the build on any known vulnerability.
+      - name: pip-audit
+        run: uv run --with pip-audit pip-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: both jobs only read the checked-out code.
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: Semgrep SAST

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 248
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T10:29:28Z"
+  "generated_at": "2026-06-22T10:54:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -216,7 +212,7 @@
         "filename": "just_akash/api.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 652
+        "line_number": 760
       }
     ],
     "just_akash/deploy.py": [
@@ -225,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 247
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -343,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-10T21:16:29Z"
+  "generated_at": "2026-06-22T10:29:28Z"
 }

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,15 @@
+# Semgrep scan exclusions.
+#
+# Test and e2e orchestration legitimately uses shell=True and passes test-built
+# commands to subprocess (deploy/cleanup harnesses). It is not part of the
+# shipped attack surface, so exclude it from the security scan.
+tests/
+just_akash/test_lifecycle.py
+just_akash/test_secrets_e2e.py
+just_akash/test_shell_e2e.py
+just_akash/_e2e.py
+
+# Vendored / generated / non-source
+.venv/
+.git/
+.planning/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Full lifecycle Console-API coverage** — five new commands close the gaps between deploy and teardown:
+  - `update` — update a running deployment in place via `PUT /v1/deployments/{dseq}`. Reuses the same SDL preparation as `deploy` (validation, `--image`, `--env`, SSH-key injection) but keeps the DSEQ and existing lease; no re-bid. CLI: `just-akash update --dseq <d> --sdl <f>`; recipe: `just update SDL [dseq] [image]`.
+  - `logs` — stream container logs from the provider via the Console provider-proxy (`--follow`, `--tail`, `--service`). CLI: `just-akash logs`; recipe: `just logs [dseq] [follow]`.
+  - `events` — stream Kubernetes events for a lease to debug startup failures (image pull, OOM, scheduling). CLI: `just-akash events`; recipe: `just events [dseq]`.
+  - `add-funds` — add USD to a deployment's escrow via `POST /v1/deposit-deployment` (minimum 0.5, confirmation prompt). CLI: `just-akash add-funds --deposit <usd>`; recipe: `just add-funds AMOUNT [dseq]`.
+  - `auto-topup` — show or toggle automatic escrow top-up via `/v2/deployment-settings` (GET/POST/PATCH upsert). CLI: `just-akash auto-topup [--on|--off]`; recipe: `just auto-topup [dseq] [on|off]`.
+- API client: `update_deployment`, `deposit_deployment`, `get_deployment_settings`, `create_deployment_settings`, `update_deployment_settings`, `set_auto_top_up` (upsert).
+- Transport: `LeaseShellTransport.stream_logs` / `stream_events` reuse the provider-proxy plumbing; tolerant log/event message formatting (JSON `ServiceLogMessage` or raw text).
+- Tests: 69 new unit tests across `test_api_extensions.py`, `test_lease_stream.py`, `test_cli_extensions.py`, `test_update_flow.py`.
+
+### Changed
+- `create_jwt` / `create_jwt_with_provider` accept a `scope` parameter (defaults to `["shell"]`) so the same JWT path serves `shell`, `logs`, and `events`.
+- SDL preparation (read → validate → image/SSH/env overrides) extracted into `deploy._prepare_sdl_content`, shared by `deploy()` and `update()`.
+
+---
+
 ## [1.6.1] — 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - API client: `update_deployment`, `deposit_deployment`, `get_deployment_settings`, `create_deployment_settings`, `update_deployment_settings`, `set_auto_top_up` (upsert).
 - Transport: `LeaseShellTransport.stream_logs` / `stream_events` reuse the provider-proxy plumbing; tolerant log/event message formatting (JSON `ServiceLogMessage` or raw text).
 - Tests: 69 new unit tests across `test_api_extensions.py`, `test_lease_stream.py`, `test_cli_extensions.py`, `test_update_flow.py`.
+- **Adversarial hardening** (`/nf:harden`, 6 iterations to convergence): fixed 9 edge-case bugs in the new lifecycle code (loose 404 detection, dropped/`0` log+event messages, blank-line streaming, image-override hijacking a comment, non-bool auto-topup display, `{"data": null}` wrapper leak breaking first-time auto-topup, non-finite `add-funds` deposit) — see `harden iteration` commits.
+- **Security tooling**: ruff bandit rules (`S`), a Semgrep SAST scan (`just semgrep`), and a pip-audit dependency CVE check (`just audit`), all wired into CI (`.github/workflows/security.yml`, weekly schedule for CVEs). See `SECURITY.md`.
 
 ### Changed
 - `create_jwt` / `create_jwt_with_provider` accept a `scope` parameter (defaults to `["shell"]`) so the same JWT path serves `shell`, `logs`, and `events`.
 - SDL preparation (read → validate → image/SSH/env overrides) extracted into `deploy._prepare_sdl_content`, shared by `deploy()` and `update()`.
+
+### Security
+- `inject` SSH-fallback path now `shlex.quote`s the user-supplied `--remote-path` before it reaches the remote shell, matching the lease-shell transport (prevents remote-shell metacharacter interpretation).
+- Corrected `deploy --deposit` help and log line: deposits are denominated in **USD**, not AKT (verified against the Console API source).
 
 ---
 

--- a/Justfile
+++ b/Justfile
@@ -306,6 +306,22 @@ check:
 secrets:
     gitleaks detect --no-banner -v
 
+# ── Security (SAST + dependency CVEs) ────────────────
+
+# Static security scan with Semgrep (excludes 2 CLI-inherent rules; see SECURITY.md)
+semgrep:
+    #!/bin/bash
+    set -euo pipefail
+    uvx semgrep scan \
+      --config p/python --config p/security-audit \
+      --exclude-rule python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args \
+      --exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
+      --error --metrics off just_akash/
+
+# Dependency CVE audit (pip-audit over the synced environment).
+audit:
+    uv run --with pip-audit pip-audit
+
 # ── Advanced ─────────────────────────────────────────
 
 # Deploy with custom SDL (e.g. no SSH, different image)

--- a/Justfile
+++ b/Justfile
@@ -37,6 +37,25 @@ connect dseq="" transport="":
     if [ -n "{{transport}}" ]; then cmd="$cmd --transport {{transport}}"; fi
     eval "$cmd"
 
+# Update a running instance in place with a revised SDL (no re-bid, keeps DSEQ).
+# Usage: just update SDL [dseq] [image]
+#   just update sdl/cpu-backtest-ssh.yaml
+#   just update sdl/cpu-backtest-ssh.yaml akash-node ghcr.io/me/app:v2
+update sdl dseq="" image="":
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/update-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=update finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=update started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file sdl={{sdl}} dseq={{dseq}} image={{image}}"
+    set -x
+    cmd="uv run just-akash update --sdl {{sdl}}"
+    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
+    if [ -n "{{image}}" ]; then cmd="$cmd --image {{image}}"; fi
+    eval "$cmd"
+
 # Destroy an instance (picks interactively if no DSEQ given)
 destroy dseq="":
     #!/bin/bash
@@ -148,6 +167,79 @@ status dseq="":
     else
         uv run just-akash status
     fi
+
+# Stream container logs (picks interactively if no DSEQ given).
+# Usage: just logs [dseq] [follow]   (pass any non-empty follow arg to tail -f)
+#   just logs akash-node
+#   just logs akash-node follow
+logs dseq="" follow="":
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/logs-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=logs finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=logs started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} follow={{follow}}"
+    set -x
+    cmd="uv run just-akash logs"
+    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
+    if [ -n "{{follow}}" ]; then cmd="$cmd --follow"; fi
+    eval "$cmd"
+
+# Stream Kubernetes events for a deployment (debug why it won't start).
+# Usage: just events [dseq]
+events dseq="":
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/events-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=events finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=events started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}}"
+    set -x
+    cmd="uv run just-akash events"
+    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
+    eval "$cmd"
+
+# ── Escrow / funding ─────────────────────────────────
+
+# Add funds (USD) to a deployment's escrow so it outlives its initial deposit.
+# Usage: just add-funds AMOUNT [dseq]   (AMOUNT in USD, minimum 0.5)
+#   just add-funds 5 akash-node
+add-funds amount dseq="":
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/add-funds-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=add-funds finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=add-funds started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file amount={{amount}} dseq={{dseq}}"
+    set -x
+    cmd="uv run just-akash add-funds --deposit {{amount}}"
+    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
+    eval "$cmd"
+
+# Show or toggle auto top-up for a deployment.
+# Usage: just auto-topup [dseq] [on|off]   (no toggle = show current setting)
+#   just auto-topup akash-node on
+auto-topup dseq="" toggle="":
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p "{{log_dir}}"
+    timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+    log_file="{{log_dir}}/auto-topup-${timestamp}.log"
+    exec > >(tee -a "$log_file") 2>&1
+    trap 'status=$?; echo "[INFO] recipe=auto-topup finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
+    echo "[INFO] recipe=auto-topup started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} toggle={{toggle}}"
+    set -x
+    cmd="uv run just-akash auto-topup"
+    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
+    if [ "{{toggle}}" = "on" ]; then cmd="$cmd --on"; fi
+    if [ "{{toggle}}" = "off" ]; then cmd="$cmd --off"; fi
+    eval "$cmd"
 
 # ── Testing ──────────────────────────────────────────
 

--- a/Justfile
+++ b/Justfile
@@ -51,10 +51,10 @@ update sdl dseq="" image="":
     trap 'status=$?; echo "[INFO] recipe=update finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=update started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file sdl={{sdl}} dseq={{dseq}} image={{image}}"
     set -x
-    cmd="uv run just-akash update --sdl {{sdl}}"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ -n "{{image}}" ]; then cmd="$cmd --image {{image}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash update --sdl "{{sdl}}")
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ -n "{{image}}" ]; then args+=(--image "{{image}}"); fi
+    "${args[@]}"
 
 # Destroy an instance (picks interactively if no DSEQ given)
 destroy dseq="":
@@ -182,10 +182,10 @@ logs dseq="" follow="":
     trap 'status=$?; echo "[INFO] recipe=logs finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=logs started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} follow={{follow}}"
     set -x
-    cmd="uv run just-akash logs"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ -n "{{follow}}" ]; then cmd="$cmd --follow"; fi
-    eval "$cmd"
+    args=(uv run just-akash logs)
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ -n "{{follow}}" ]; then args+=(--follow); fi
+    "${args[@]}"
 
 # Stream Kubernetes events for a deployment (debug why it won't start).
 # Usage: just events [dseq]
@@ -199,9 +199,9 @@ events dseq="":
     trap 'status=$?; echo "[INFO] recipe=events finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=events started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}}"
     set -x
-    cmd="uv run just-akash events"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash events)
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    "${args[@]}"
 
 # ── Escrow / funding ─────────────────────────────────
 
@@ -218,9 +218,9 @@ add-funds amount dseq="":
     trap 'status=$?; echo "[INFO] recipe=add-funds finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=add-funds started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file amount={{amount}} dseq={{dseq}}"
     set -x
-    cmd="uv run just-akash add-funds --deposit {{amount}}"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash add-funds --deposit "{{amount}}")
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    "${args[@]}"
 
 # Show or toggle auto top-up for a deployment.
 # Usage: just auto-topup [dseq] [on|off]   (no toggle = show current setting)
@@ -235,11 +235,11 @@ auto-topup dseq="" toggle="":
     trap 'status=$?; echo "[INFO] recipe=auto-topup finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=auto-topup started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} toggle={{toggle}}"
     set -x
-    cmd="uv run just-akash auto-topup"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ "{{toggle}}" = "on" ]; then cmd="$cmd --on"; fi
-    if [ "{{toggle}}" = "off" ]; then cmd="$cmd --off"; fi
-    eval "$cmd"
+    args=(uv run just-akash auto-topup)
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ "{{toggle}}" = "on" ]; then args+=(--on); fi
+    if [ "{{toggle}}" = "off" ]; then args+=(--off); fi
+    "${args[@]}"
 
 # ── Testing ──────────────────────────────────────────
 

--- a/Justfile
+++ b/Justfile
@@ -32,10 +32,10 @@ connect dseq="" transport="":
     trap 'status=$?; echo "[INFO] recipe=connect finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=connect started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}}"
     set -x
-    cmd="uv run just-akash connect"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ -n "{{transport}}" ]; then cmd="$cmd --transport {{transport}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash connect)
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ -n "{{transport}}" ]; then args+=(--transport "{{transport}}"); fi
+    "${args[@]}"
 
 # Update a running instance in place with a revised SDL (no re-bid, keeps DSEQ).
 # Usage: just update SDL [dseq] [image]
@@ -114,10 +114,10 @@ inject dseq="" env-file=".env.secrets" transport="":
     trap 'status=$?; echo "[INFO] recipe=inject finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=inject started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} env_file={{env-file}}"
     set -x
-    cmd="uv run just-akash inject --env-file {{env-file}}"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ -n "{{transport}}" ]; then cmd="$cmd --transport {{transport}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash inject --env-file "{{env-file}}")
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ -n "{{transport}}" ]; then args+=(--transport "{{transport}}"); fi
+    "${args[@]}"
 
 # Execute a command on a running instance via lease-shell (default) or SSH
 # Usage: just exec [dseq] [transport=lease-shell|ssh] "command"
@@ -131,10 +131,11 @@ exec dseq="" command="" transport="":
     trap 'status=$?; echo "[INFO] recipe=exec finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=exec started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file dseq={{dseq}} command={{command}}"
     set -x
-    cmd="uv run just-akash exec '{{command}}'"
-    if [ -n "{{dseq}}" ]; then cmd="$cmd --dseq={{dseq}}"; fi
-    if [ -n "{{transport}}" ]; then cmd="$cmd --transport {{transport}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash exec)
+    if [ -n "{{dseq}}" ]; then args+=(--dseq "{{dseq}}"); fi
+    if [ -n "{{transport}}" ]; then args+=(--transport "{{transport}}"); fi
+    args+=("{{command}}")
+    "${args[@]}"
 
 # ── Info ─────────────────────────────────────────────
 
@@ -335,9 +336,9 @@ deploy sdl="sdl/cpu-backtest-ssh.yaml" image="":
     trap 'status=$?; echo "[INFO] recipe=deploy finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") exit_code=${status} log_file=${log_file}"' EXIT
     echo "[INFO] recipe=deploy started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ") cwd=$PWD log_file=$log_file sdl={{sdl}} image={{image}}"
     set -x
-    cmd="uv run just-akash deploy --sdl {{sdl}}"
-    if [ -n "{{image}}" ]; then cmd="$cmd --image {{image}}"; fi
-    eval "$cmd"
+    args=(uv run just-akash deploy --sdl "{{sdl}}")
+    if [ -n "{{image}}" ]; then args+=(--image "{{image}}"); fi
+    "${args[@]}"
 
 # ── Akash node (personal LCD/RPC) ────────────────────
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ Self-contained — clone, configure `.env`, and run.
 
 ## What's New in v1.6.0
 
+- **Full lifecycle API coverage** — five new commands round out the deploy→operate→maintain loop:
+  - `update` — revise a running deployment in place (`PUT /v1/deployments/{dseq}`); keeps the DSEQ and lease, no re-bid.
+  - `logs` — stream container logs from the provider (`--follow`, `--tail`, `--service`).
+  - `events` — stream Kubernetes events to debug why a deployment won't start.
+  - `add-funds` — top up a deployment's escrow in USD (`POST /v1/deposit-deployment`).
+  - `auto-topup` — show or toggle automatic escrow top-up (`/v2/deployment-settings`).
 - **Tiered provider selection** — preferred + backup allowlists with a 3-phase bid-selection state machine (`AKASH_PROVIDERS_BACKUP` env var, `--provider` / `--backup-provider` CLI flags). See [Bid Selection](#bid-selection).
 - **BME migration** — bid-price denom defaults updated from `uakt` (legacy) to `uact`.
 - **Hardened e2e cleanup** — `robust_destroy()` with retry + audit, SIGINT/SIGTERM-safe handler, no-leak guarantee on multi-deployment runs.
-- **653 tests** (109 new); `just_akash/deploy.py` and `just_akash/_e2e.py` at 100% line coverage.
+- **722 tests**; `just_akash/deploy.py` and `just_akash/_e2e.py` at 100% line coverage.
 
 ## Prerequisites
 
@@ -41,9 +47,14 @@ uv run pre-commit install   # install gitleaks + ruff hooks
 |---|---|---|
 | `just deploy [sdl] [image]` | `just deploy` | Deploy with custom SDL/image |
 | `just up [tag]` | `just up my-web-app` | Deploy SSH instance + optional tag |
+| `just update SDL [dseq] [image]` | `just update sdl/app.yaml akash-node` | Update a deployment in place (no re-bid, keeps DSEQ/lease) |
 | `just connect [dseq] [transport]` | `just connect 12345 ssh` | Connect to a running instance (lease-shell default) |
 | `just exec [dseq] "cmd" [transport]` | `just exec 12345 "ls -la"` | Execute a remote command |
 | `just inject [dseq] [env-file] [transport]` | `just inject 12345 .env.secrets` | Inject secrets (lease-shell default) |
+| `just logs [dseq] [follow]` | `just logs akash-node follow` | Stream container logs (provider-proxy) |
+| `just events [dseq]` | `just events akash-node` | Stream Kubernetes events (debug startup) |
+| `just add-funds AMOUNT [dseq]` | `just add-funds 5 akash-node` | Add USD to escrow (min 0.5) |
+| `just auto-topup [dseq] [on\|off]` | `just auto-topup akash-node on` | Show / toggle auto escrow top-up |
 | `just destroy [dseq]` | `just destroy 12345` | Destroy an instance |
 | `just destroy-all` | `just destroy-all` | Destroy all instances |
 | `just list` | `just list` | List active instances |
@@ -98,6 +109,9 @@ uv run just-akash deploy --sdl sdl/cpu-backtest-ssh.yaml
 # Deploy with env vars (provider-visible)
 uv run just-akash deploy --sdl sdl/cpu-backtest-ssh.yaml --env REGION=us-east
 
+# Update an existing deployment in place (new SDL/image, same DSEQ + lease)
+uv run just-akash update --dseq 12345 --sdl sdl/cpu-backtest-ssh.yaml --image repo/app:v2
+
 # Connect / exec / inject
 uv run just-akash connect --dseq 12345
 uv run just-akash exec --dseq 12345 "echo hello"
@@ -106,6 +120,16 @@ uv run just-akash inject --dseq 12345 --env-file .env.secrets
 # Force SSH transport
 uv run just-akash exec --dseq 12345 --transport ssh "echo hello"
 uv run just-akash inject --dseq 12345 --transport ssh --env-file .env.secrets
+
+# Stream logs (snapshot or --follow) and Kubernetes events
+uv run just-akash logs --dseq 12345 --tail 200
+uv run just-akash logs --dseq 12345 --follow --service web
+uv run just-akash events --dseq 12345
+
+# Escrow: add USD funds, or toggle automatic top-up
+uv run just-akash add-funds --dseq 12345 --deposit 5
+uv run just-akash auto-topup --dseq 12345 --on
+uv run just-akash auto-topup --dseq 12345        # show current setting
 
 # List / status / destroy
 uv run just-akash list

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Self-contained — clone, configure `.env`, and run.
 - **Tiered provider selection** — preferred + backup allowlists with a 3-phase bid-selection state machine (`AKASH_PROVIDERS_BACKUP` env var, `--provider` / `--backup-provider` CLI flags). See [Bid Selection](#bid-selection).
 - **BME migration** — bid-price denom defaults updated from `uakt` (legacy) to `uact`.
 - **Hardened e2e cleanup** — `robust_destroy()` with retry + audit, SIGINT/SIGTERM-safe handler, no-leak guarantee on multi-deployment runs.
-- **722 tests**; `just_akash/deploy.py` and `just_akash/_e2e.py` at 100% line coverage.
+- **Extensive unit + e2e test suite**; `just_akash/deploy.py` and `just_akash/_e2e.py` at 100% line coverage.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ uv run pre-commit install   # install gitleaks + ruff hooks
 | `just tag [dseq] [name]` | `just tag 12345 my-db` | Tag a deployment with a name |
 | `just test-shell` | `just test-shell` | E2E lease-shell transport test (deploy/exec/inject/cleanup) |
 | `just test-secrets` | `just test-secrets` | E2E secrets injection test (SSH inject + lease-shell cross-check) |
-| `just lint` | `just lint` | Ruff lint + format check |
+| `just lint` | `just lint` | Ruff lint + format check (incl. bandit `S` security rules) |
 | `just secrets` | `just secrets` | Gitleaks secret scan |
+| `just semgrep` | `just semgrep` | Semgrep SAST scan |
+| `just audit` | `just audit` | Dependency CVE audit (pip-audit) |
 
 Transport: `connect`, `exec`, and `inject` default to `lease-shell`. Pass `ssh` as the last argument to force SSH: `just exec 12345 "cmd" ssh`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Self-contained — clone, configure `.env`, and run.
 > commitment to making Akash enterprise-ready — adding robustness to the deployment lifecycle and
 > security to post-deploy operations (no-SSH lease-shell exec, off-SDL secret injection).
 
-## What's New in v1.6.0
+## What's New
 
 - **Full lifecycle API coverage** — five new commands round out the deploy→operate→maintain loop:
   - `update` — revise a running deployment in place (`PUT /v1/deployments/{dseq}`); keeps the DSEQ and lease, no re-bid.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,25 @@ This repository uses three layers of secret detection:
 - **detect-secrets** — baseline file + CI diff check
 
 If you find a secret in the repository, report it immediately using the process above.
+
+## Static Analysis & Dependency Auditing
+
+In addition to secret scanning, the repository runs:
+
+- **Ruff bandit rules (`S`)** — Python security SAST on every push/PR (the `lint`
+  CI job). Catches `shell=True` (`S602`), unsafe temp files, weak SSL, etc.
+  `assert`-based tests and shell-based e2e orchestration are scoped out via
+  per-file ignores; `S603`/`S606`/`S607` (subprocess/exec mechanics) are ignored
+  globally because invoking `ssh` is this tool's intended function — it builds
+  argv lists (never `shell=True`) and resolves `ssh` from `PATH`.
+- **Semgrep** (`p/python` + `p/security-audit`) — the `Semgrep SAST` security job
+  (`just semgrep`). Two rules are excluded because they are inherent to a
+  remote-exec CLI and the underlying risk is mitigated in code:
+    - `dangerous-subprocess-use-tainted-env-args` — the tool runs commands and
+      writes files on the **user's own** deployment by design; user-supplied
+      paths are passed through `shlex.quote`.
+    - `dynamic-urllib-use-detected` — the request URL is built from the
+      operator-set Console API base URL, not external/attacker input.
+  `subprocess-shell-true` (real shell-injection) and all other rules stay active.
+- **pip-audit** — dependency CVE audit on every push/PR and weekly (`just audit`),
+  failing the build on any known vulnerability in a locked dependency.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,11 @@ In addition to secret scanning, the repository runs:
 - **Ruff bandit rules (`S`)** — Python security SAST on every push/PR (the `lint`
   CI job). Catches `shell=True` (`S602`), unsafe temp files, weak SSL, etc.
   `assert`-based tests and shell-based e2e orchestration are scoped out via
-  per-file ignores; `S603`/`S606`/`S607` (subprocess/exec mechanics) are ignored
-  globally because invoking `ssh` is this tool's intended function — it builds
-  argv lists (never `shell=True`) and resolves `ssh` from `PATH`.
+  per-file ignores. `S603`/`S606`/`S607` (subprocess/exec mechanics) are
+  per-file-ignored only for the modules that invoke `ssh` by design
+  (`just_akash/api.py`, `cli.py`, `transport/ssh.py`) — they build argv lists
+  (never `shell=True`) and resolve `ssh` from `PATH`. Scoping them per-file
+  (rather than globally) keeps a new unsafe subprocess elsewhere failing CI.
 - **Semgrep** (`p/python` + `p/security-audit`) — the `Semgrep SAST` security job
   (`just semgrep`). Two rules are excluded because they are inherent to a
   remote-exec CLI and the underlying risk is mitigated in code:

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -207,6 +207,100 @@ class AkashConsoleAPI:
         data = response.get("data", response)
         return data if isinstance(data, dict) else response
 
+    def update_deployment(self, dseq: str, sdl_content: str) -> dict[str, Any]:
+        """Update an active deployment in place with a revised SDL.
+
+        PUTs to /v1/deployments/{dseq}. The on-chain deployment keeps its DSEQ
+        and existing lease — no re-bid or new lease is required. Returns the
+        full deployment object (same shape as get_deployment).
+        """
+        response = self._request(
+            "PUT",
+            f"/v1/deployments/{dseq}",
+            {"data": {"sdl": sdl_content}},
+        )
+        if not isinstance(response, dict):
+            return {}
+        data = response.get("data", response)
+        return data if isinstance(data, dict) else response
+
+    def deposit_deployment(self, dseq: str, deposit: float) -> dict[str, Any]:
+        """Add funds to an existing deployment's escrow.
+
+        POSTs to /v1/deposit-deployment. ``deposit`` is in USD (minimum 0.5 per
+        the Console API). Returns the full deployment object after top-up.
+        """
+        response = self._request(
+            "POST",
+            "/v1/deposit-deployment",
+            {"data": {"dseq": str(dseq), "deposit": deposit}},
+        )
+        if not isinstance(response, dict):
+            return {}
+        data = response.get("data", response)
+        return data if isinstance(data, dict) else response
+
+    def get_deployment_settings(self, dseq: str) -> dict[str, Any]:
+        """Fetch auto top-up settings for a deployment.
+
+        GETs /v2/deployment-settings/{dseq}. Returns the settings object, or an
+        empty dict if no settings have been created yet (some deployments 404
+        until settings are first POSTed — callers should treat {} as "unset").
+        """
+        try:
+            response = self._request("GET", f"/v2/deployment-settings/{dseq}")
+        except RuntimeError as e:
+            # No settings yet is reported as a 404 by the Console API.
+            if "404" in str(e) or "not found" in str(e).lower():
+                return {}
+            raise
+        if not isinstance(response, dict):
+            return {}
+        data = response.get("data", response)
+        return data if isinstance(data, dict) else response
+
+    def create_deployment_settings(self, dseq: str, auto_top_up_enabled: bool) -> dict[str, Any]:
+        """Create deployment settings (first-time auto top-up config).
+
+        POSTs to /v2/deployment-settings. Use update_deployment_settings to
+        change settings that already exist.
+        """
+        response = self._request(
+            "POST",
+            "/v2/deployment-settings",
+            {"data": {"dseq": str(dseq), "autoTopUpEnabled": auto_top_up_enabled}},
+        )
+        if not isinstance(response, dict):
+            return {}
+        data = response.get("data", response)
+        return data if isinstance(data, dict) else response
+
+    def update_deployment_settings(self, dseq: str, auto_top_up_enabled: bool) -> dict[str, Any]:
+        """Update existing deployment settings.
+
+        PATCHes /v2/deployment-settings/{dseq}.
+        """
+        response = self._request(
+            "PATCH",
+            f"/v2/deployment-settings/{dseq}",
+            {"data": {"autoTopUpEnabled": auto_top_up_enabled}},
+        )
+        if not isinstance(response, dict):
+            return {}
+        data = response.get("data", response)
+        return data if isinstance(data, dict) else response
+
+    def set_auto_top_up(self, dseq: str, enabled: bool) -> dict[str, Any]:
+        """Enable or disable auto top-up, upserting settings as needed.
+
+        Reads current settings: PATCHes if they already exist, otherwise POSTs
+        to create them. Returns the resulting settings object.
+        """
+        existing = self.get_deployment_settings(dseq)
+        if existing:
+            return self.update_deployment_settings(dseq, enabled)
+        return self.create_deployment_settings(dseq, enabled)
+
     def close_deployment(self, dseq: str) -> dict[str, Any]:
         response = self._request("DELETE", f"/v1/deployments/{dseq}")
         if not isinstance(response, dict):
@@ -285,8 +379,8 @@ class AkashConsoleAPI:
             return {}
         return response
 
-    def create_jwt(self, dseq: str, ttl: int = 3600) -> str:
-        """Request a short-lived JWT for lease-shell auth.
+    def create_jwt(self, dseq: str, ttl: int = 3600, scope: list[str] | None = None) -> str:
+        """Request a short-lived JWT for provider access (shell, logs, events…).
 
         POSTs to /v1/create-jwt-token with the existing api_key.
         Returns the JWT string. Raises RuntimeError on HTTP error.
@@ -295,11 +389,16 @@ class AkashConsoleAPI:
             dseq: Deployment sequence number (string).
             ttl:  Requested TTL in seconds (server default is 30s; request 3600 and
                   fall back to reconnect if server caps it — see LSHL-03 in Phase 7).
+            scope: Permission scopes to request (e.g. ["shell"], ["logs"],
+                  ["events"]). Defaults to ["shell"]. Valid values: send-manifest,
+                  get-manifest, logs, shell, events, status, restart,
+                  hostname-migrate, ip-migrate.
         """
+        scope = scope or ["shell"]
         response = self._request(
             "POST",
             "/v1/create-jwt-token",
-            {"data": {"ttl": ttl, "leases": {"access": "full", "scope": ["shell"]}}},
+            {"data": {"ttl": ttl, "leases": {"access": "full", "scope": scope}}},
         )
         # Response shape: { "data": { "token": "<JWT>" } }
         if not isinstance(response, dict):
@@ -311,11 +410,16 @@ class AkashConsoleAPI:
                 return token
         raise RuntimeError(f"JWT token not found in response: {response}")
 
-    def create_jwt_with_provider(self, dseq: str, provider: str, ttl: int = 3600) -> str:
+    def create_jwt_with_provider(
+        self, dseq: str, provider: str, ttl: int = 3600, scope: list[str] | None = None
+    ) -> str:
         """Request a short-lived JWT scoped to a specific provider.
 
-        Uses granular access with scoped permissions for shell access.
+        Uses granular access with scoped permissions. ``scope`` selects which
+        provider operations the token authorizes (defaults to ["shell"]; pass
+        ["logs"] or ["events"] for streaming).
         """
+        scope = scope or ["shell"]
         response = self._request(
             "POST",
             "/v1/create-jwt-token",
@@ -328,7 +432,7 @@ class AkashConsoleAPI:
                             {
                                 "provider": provider,
                                 "access": "scoped",
-                                "scope": ["shell"],
+                                "scope": scope,
                             }
                         ],
                     },

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -125,7 +125,9 @@ class AkashConsoleAPI:
 
         request_body = json.dumps(data).encode("utf-8") if data else None
 
-        req = urllib.request.Request(
+        # S310: the URL is built from base_url, which defaults to the https
+        # Console API and is operator-set (env var), not external/attacker input.
+        req = urllib.request.Request(  # noqa: S310
             url,
             data=request_body,
             headers=self.headers,
@@ -134,7 +136,7 @@ class AkashConsoleAPI:
 
         try:
             t0 = datetime.now(timezone.utc)
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req) as response:  # noqa: S310
                 response_data = response.read().decode("utf-8")
                 elapsed_ms = int((datetime.now(timezone.utc) - t0).total_seconds() * 1000)
                 if response_data:

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -250,8 +250,11 @@ class AkashConsoleAPI:
         try:
             response = self._request("GET", f"/v2/deployment-settings/{dseq}")
         except RuntimeError as e:
-            # No settings yet is reported as a 404 by the Console API.
-            if "404" in str(e) or "not found" in str(e).lower():
+            # No settings yet is reported as HTTP 404. Match the status code
+            # precisely (_request formats errors as "API Error (404): ...");
+            # a substring search would misclassify a 400/500 whose body merely
+            # contains "404" (e.g. dseq 40400) or the phrase "not found".
+            if str(e).startswith("API Error (404)"):
                 return {}
             raise
         if not isinstance(response, dict):

--- a/just_akash/api.py
+++ b/just_akash/api.py
@@ -82,6 +82,20 @@ def _json_output(data: dict[str, Any] | list[Any]) -> str:
     return json.dumps(data, indent=2)
 
 
+def _unwrap_data(response: Any) -> dict[str, Any]:
+    """Extract the dict payload from a Console API response.
+
+    Accepts both the ``{"data": {...}}`` envelope and a bare dict body. Returns
+    ``{}`` for anything without a usable dict payload — including the
+    ``{"data": null}`` shape some endpoints use for "no record", which must NOT
+    leak back to callers as a truthy wrapper.
+    """
+    if not isinstance(response, dict):
+        return {}
+    data = response.get("data", response)
+    return data if isinstance(data, dict) else {}
+
+
 class AkashConsoleAPI:
     """Client for Akash Console API (https://console-api.akash.network)"""
 
@@ -219,10 +233,7 @@ class AkashConsoleAPI:
             f"/v1/deployments/{dseq}",
             {"data": {"sdl": sdl_content}},
         )
-        if not isinstance(response, dict):
-            return {}
-        data = response.get("data", response)
-        return data if isinstance(data, dict) else response
+        return _unwrap_data(response)
 
     def deposit_deployment(self, dseq: str, deposit: float) -> dict[str, Any]:
         """Add funds to an existing deployment's escrow.
@@ -235,10 +246,7 @@ class AkashConsoleAPI:
             "/v1/deposit-deployment",
             {"data": {"dseq": str(dseq), "deposit": deposit}},
         )
-        if not isinstance(response, dict):
-            return {}
-        data = response.get("data", response)
-        return data if isinstance(data, dict) else response
+        return _unwrap_data(response)
 
     def get_deployment_settings(self, dseq: str) -> dict[str, Any]:
         """Fetch auto top-up settings for a deployment.
@@ -257,10 +265,7 @@ class AkashConsoleAPI:
             if str(e).startswith("API Error (404)"):
                 return {}
             raise
-        if not isinstance(response, dict):
-            return {}
-        data = response.get("data", response)
-        return data if isinstance(data, dict) else response
+        return _unwrap_data(response)
 
     def create_deployment_settings(self, dseq: str, auto_top_up_enabled: bool) -> dict[str, Any]:
         """Create deployment settings (first-time auto top-up config).
@@ -273,10 +278,7 @@ class AkashConsoleAPI:
             "/v2/deployment-settings",
             {"data": {"dseq": str(dseq), "autoTopUpEnabled": auto_top_up_enabled}},
         )
-        if not isinstance(response, dict):
-            return {}
-        data = response.get("data", response)
-        return data if isinstance(data, dict) else response
+        return _unwrap_data(response)
 
     def update_deployment_settings(self, dseq: str, auto_top_up_enabled: bool) -> dict[str, Any]:
         """Update existing deployment settings.
@@ -288,10 +290,7 @@ class AkashConsoleAPI:
             f"/v2/deployment-settings/{dseq}",
             {"data": {"autoTopUpEnabled": auto_top_up_enabled}},
         )
-        if not isinstance(response, dict):
-            return {}
-        data = response.get("data", response)
-        return data if isinstance(data, dict) else response
+        return _unwrap_data(response)
 
     def set_auto_top_up(self, dseq: str, enabled: bool) -> dict[str, Any]:
         """Enable or disable auto top-up, upserting settings as needed.

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -689,7 +689,9 @@ def main():
                 if not settings:
                     print(f"Deployment {label}: auto top-up not configured (off).")
                 else:
-                    enabled = bool(settings.get("autoTopUpEnabled", False))
+                    # Only a real boolean True means enabled; a non-bool value
+                    # (e.g. the string "false") must not read as truthy "on".
+                    enabled = settings.get("autoTopUpEnabled") is True
                     print(f"Deployment {label}: auto top-up {'on' if enabled else 'off'}")
                     for key in ("estimatedTopUpAmount", "topUpFrequencyMs"):
                         if key in settings:

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -24,6 +24,7 @@ import argparse
 import logging
 import math
 import os
+import shlex
 import subprocess
 import sys
 
@@ -457,6 +458,8 @@ def main():
                 ssh, ssh_cmd = _require_ssh(client, dseq, args.key)
                 ssh_cmd.append(args.remote_cmd)
                 print(f"Executing on {ssh['host']}:{ssh['port']}...")
+                # `exec` runs a user-supplied command on the user's own deployment
+                # by design (this is `ssh host <cmd>`); the command is the feature.
                 result = subprocess.run(ssh_cmd, text=True)
                 sys.exit(result.returncode)
         except RuntimeError as e:
@@ -520,15 +523,20 @@ def main():
             else:
                 ssh, ssh_cmd = _require_ssh(client, dseq, args.key)
                 remote_path = args.remote_path
+                # Quote the user-supplied path before it reaches the remote
+                # shell (ssh runs the trailing arg via /bin/sh), matching the
+                # lease-shell transport. Prevents metacharacters in --remote-path
+                # from being interpreted remotely.
+                quoted_path = shlex.quote(remote_path)
                 secrets_content = "\n".join(env_lines) + "\n"
 
-                mkdir_cmd = ssh_cmd + [f"mkdir -p $(dirname {remote_path})"]
+                mkdir_cmd = ssh_cmd + [f"mkdir -p $(dirname {quoted_path})"]
                 result = subprocess.run(mkdir_cmd, capture_output=True, text=True)
                 if result.returncode != 0:
                     print(f"Error creating remote directory: {result.stderr.strip()}")
                     sys.exit(1)
 
-                write_cmd = ssh_cmd + [f"cat > {remote_path}"]
+                write_cmd = ssh_cmd + [f"cat > {quoted_path}"]
                 result = subprocess.run(
                     write_cmd, input=secrets_content, capture_output=True, text=True
                 )
@@ -536,7 +544,7 @@ def main():
                     print(f"Error writing secrets: {result.stderr.strip()}")
                     sys.exit(1)
 
-                chmod_cmd = ssh_cmd + [f"chmod 600 {remote_path}"]
+                chmod_cmd = ssh_cmd + [f"chmod 600 {quoted_path}"]
                 subprocess.run(chmod_cmd, capture_output=True, text=True)
 
                 print(f"Injected {len(env_lines)} secret(s) into {dseq}:{remote_path}")

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -22,6 +22,7 @@ Subcommands:
 
 import argparse
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -653,7 +654,7 @@ def main():
         from .api import AkashConsoleAPI, _confirm, _get_tag
 
         try:
-            if args.deposit < 0.5:
+            if not math.isfinite(args.deposit) or args.deposit < 0.5:
                 print("Error: minimum deposit is 0.5 USD.", file=sys.stderr)
                 sys.exit(1)
             client = AkashConsoleAPI(_require_api_key())

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -81,12 +81,25 @@ def _enrich_deployment_with_provider(client, deployment: dict) -> dict:
     """Inject provider hostUri into each lease so lease_shell transport can find it.
 
     The Console API /v1/deployments/{dseq} response stores the provider address as
-    lease["id"]["provider"] but omits the hostUri.  We fetch it and inject a
-    "provider" dict matching the format expected by LeaseShellTransport.
+    lease["id"]["provider"] but may omit (or leave blank) the hostUri. We resolve
+    it from the provider registry and inject a "provider" dict in the shape
+    LeaseShellTransport expects. Tolerant of unexpected API shapes.
     """
-    for lease in deployment.get("leases", []):
-        provider_addr = lease.get("id", {}).get("provider", "")
-        if provider_addr and not isinstance(lease.get("provider"), dict):
+    leases = deployment.get("leases")
+    if not isinstance(leases, list):
+        return deployment
+    for lease in leases:
+        if not isinstance(lease, dict):
+            continue
+        lease_id = lease.get("id")
+        provider_addr = lease_id.get("provider", "") if isinstance(lease_id, dict) else ""
+        if not provider_addr:
+            continue
+        provider = lease.get("provider")
+        existing_host = provider.get("hostUri") if isinstance(provider, dict) else None
+        # Backfill when the provider dict is missing OR carries a blank hostUri,
+        # so a registry-resolvable host isn't wrongly treated as "no host".
+        if not existing_host:
             info = client.get_provider(provider_addr) or {}
             lease["provider"] = {"hostUri": info.get("hostUri", "")}
     return deployment
@@ -662,7 +675,10 @@ def main():
         from .api import AkashConsoleAPI, _confirm, _get_tag
 
         try:
-            if not math.isfinite(args.deposit) or args.deposit < 0.5:
+            if not math.isfinite(args.deposit):
+                print("Error: deposit must be a finite number.", file=sys.stderr)
+                sys.exit(1)
+            if args.deposit < 0.5:
                 print("Error: minimum deposit is 0.5 USD.", file=sys.stderr)
                 sys.exit(1)
             client = AkashConsoleAPI(_require_api_key())

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -643,6 +643,9 @@ def main():
         from .api import AkashConsoleAPI
 
         try:
+            if args.tail < 0:
+                print("Error: --tail must be >= 0.", file=sys.stderr)
+                sys.exit(1)
             client = AkashConsoleAPI(_require_api_key())
             dseq = _resolve_deployment(client, args.dseq)
             transport = _make_lease_shell(client, dseq)

--- a/just_akash/cli.py
+++ b/just_akash/cli.py
@@ -4,9 +4,14 @@ Unified CLI for just-akash.
 
 Subcommands:
   deploy      — Deploy to Akash Network
+  update      — Update a running deployment in place (no re-bid)
   connect     — SSH into a running deployment
   exec        — Execute a command on a running deployment
   inject      — Inject secrets into a running deployment via SSH
+  logs        — Stream container logs from a deployment
+  events      — Stream Kubernetes events for a deployment
+  add-funds   — Add funds (USD) to a deployment's escrow
+  auto-topup  — Show or set auto top-up for a deployment
   list        — List active deployments
   status      — Show deployment details
   destroy     — Destroy a deployment
@@ -85,6 +90,32 @@ def _enrich_deployment_with_provider(client, deployment: dict) -> dict:
     return deployment
 
 
+def _make_lease_shell(client, dseq):
+    """Build a validated lease-shell transport for read-only streaming.
+
+    Used by `logs` and `events`, which have no SSH equivalent. Returns the
+    concrete LeaseShellTransport (so its stream_logs/stream_events are visible)
+    and exits with a helpful message if the deployment has no active lease /
+    provider hostUri.
+    """
+    from .transport.base import TransportConfig
+    from .transport.lease_shell import LeaseShellTransport
+
+    deployment = _enrich_deployment_with_provider(client, client.get_deployment(dseq))
+    transport = LeaseShellTransport(
+        TransportConfig(dseq=dseq, api_key=client.api_key, deployment=deployment)
+    )
+    if not transport.validate():
+        print(
+            "Error: no active lease / provider hostUri for this deployment yet.\n"
+            "Logs and events stream from the provider, which requires an active "
+            "lease. Check 'just-akash status' and try again once it's running.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return transport
+
+
 def _require_ssh(client, dseq, key_arg):
     from .api import _build_ssh_cmd, _extract_ssh_info, _find_ssh_key
 
@@ -146,6 +177,28 @@ def main():
         default=None,
         help="Backup provider address (repeatable; overrides AKASH_PROVIDERS_BACKUP)",
     )
+    deploy_p.add_argument(
+        "--deposit",
+        type=float,
+        default=5.0,
+        help="Escrow deposit in USD (default: 5.0). Unused escrow is refunded "
+        "when the deployment closes; size it to outlast the workload.",
+    )
+
+    # ── update ─────────────────────────────────────────
+    update_p = subparsers.add_parser(
+        "update", help="Update a running deployment in place (no re-bid)"
+    )
+    update_p.add_argument("--dseq", default="")
+    update_p.add_argument("--sdl", required=True, help="Path to the revised SDL file")
+    update_p.add_argument("--image", default=None, help="Override container image")
+    update_p.add_argument(
+        "--env",
+        action="append",
+        dest="update_env_vars",
+        default=[],
+        help="KEY=VALUE env var to inject into SDL (repeatable, provider-visible)",
+    )
 
     # ── connect ────────────────────────────────────────
     connect_p = subparsers.add_parser(
@@ -204,6 +257,47 @@ def main():
         dest="transport",
         help="Transport to use: 'lease-shell' (default) or 'ssh'",
     )
+
+    # ── logs ───────────────────────────────────────────
+    logs_p = subparsers.add_parser("logs", help="Stream container logs from a deployment")
+    logs_p.add_argument("--dseq", default="")
+    logs_p.add_argument(
+        "-f", "--follow", action="store_true", help="Stream continuously (Ctrl-C to stop)"
+    )
+    logs_p.add_argument(
+        "--tail", type=int, default=100, help="Number of trailing lines to show (default: 100)"
+    )
+    logs_p.add_argument(
+        "--service", default=None, help="Filter to a single service (default: all services)"
+    )
+
+    # ── events ─────────────────────────────────────────
+    events_p = subparsers.add_parser(
+        "events", help="Stream Kubernetes events for a deployment (debug startup)"
+    )
+    events_p.add_argument("--dseq", default="")
+
+    # ── add-funds ──────────────────────────────────────
+    add_funds_p = subparsers.add_parser(
+        "add-funds", help="Add funds (USD) to a deployment's escrow"
+    )
+    add_funds_p.add_argument("--dseq", default="")
+    add_funds_p.add_argument(
+        "--deposit",
+        type=float,
+        required=True,
+        help="Amount to add in USD (minimum 0.5)",
+    )
+    add_funds_p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
+
+    # ── auto-topup ─────────────────────────────────────
+    auto_topup_p = subparsers.add_parser(
+        "auto-topup", help="Show or set auto top-up for a deployment"
+    )
+    auto_topup_p.add_argument("--dseq", default="")
+    auto_topup_group = auto_topup_p.add_mutually_exclusive_group()
+    auto_topup_group.add_argument("--on", action="store_true", help="Enable auto top-up")
+    auto_topup_group.add_argument("--off", action="store_true", help="Disable auto top-up")
 
     # ── list ───────────────────────────────────────────
     list_p = subparsers.add_parser("list", help="List active deployments")
@@ -267,6 +361,26 @@ def main():
                 env_vars=args.deploy_env_vars,
                 preferred_providers=args.preferred_providers,
                 backup_providers=args.backup_providers,
+                deposit=args.deposit,
+            )
+            sys.exit(0)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── update ─────────────────────────────────────────
+    elif args.command == "update":
+        from .api import AkashConsoleAPI
+        from .deploy import update
+
+        try:
+            client = AkashConsoleAPI(_require_api_key())
+            dseq = _resolve_deployment(client, args.dseq)
+            update(
+                dseq=dseq,
+                sdl_path=args.sdl,
+                image=args.image,
+                env_vars=args.update_env_vars,
             )
             sys.exit(0)
         except RuntimeError as e:
@@ -498,6 +612,88 @@ def main():
                 print(f"  Provider: {_extract_lease_provider(deployment) or 'no lease'}")
                 if ssh:
                     print(f"  SSH:      ssh -p {ssh['port']} root@{ssh['host']}")
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── logs ───────────────────────────────────────────
+    elif args.command == "logs":
+        from .api import AkashConsoleAPI
+
+        try:
+            client = AkashConsoleAPI(_require_api_key())
+            dseq = _resolve_deployment(client, args.dseq)
+            transport = _make_lease_shell(client, dseq)
+            try:
+                transport.stream_logs(follow=args.follow, tail=args.tail, service=args.service)
+            except KeyboardInterrupt:
+                print()
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── events ─────────────────────────────────────────
+    elif args.command == "events":
+        from .api import AkashConsoleAPI
+
+        try:
+            client = AkashConsoleAPI(_require_api_key())
+            dseq = _resolve_deployment(client, args.dseq)
+            transport = _make_lease_shell(client, dseq)
+            try:
+                transport.stream_events()
+            except KeyboardInterrupt:
+                print()
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── add-funds ──────────────────────────────────────
+    elif args.command == "add-funds":
+        from .api import AkashConsoleAPI, _confirm, _get_tag
+
+        try:
+            if args.deposit < 0.5:
+                print("Error: minimum deposit is 0.5 USD.", file=sys.stderr)
+                sys.exit(1)
+            client = AkashConsoleAPI(_require_api_key())
+            dseq = _resolve_deployment(client, args.dseq)
+            tag = _get_tag(dseq)
+            label = f"{dseq} ({tag})" if tag else dseq
+            if _confirm(f"Add {args.deposit} USD to deployment {label}? (y/N) ", yes=args.yes):
+                client.deposit_deployment(dseq, args.deposit)
+                print(f"Added {args.deposit} USD to deployment {label}.")
+            else:
+                print("Cancelled.")
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # ── auto-topup ─────────────────────────────────────
+    elif args.command == "auto-topup":
+        from .api import AkashConsoleAPI, _get_tag
+
+        try:
+            client = AkashConsoleAPI(_require_api_key())
+            dseq = _resolve_deployment(client, args.dseq)
+            tag = _get_tag(dseq)
+            label = f"{dseq} ({tag})" if tag else dseq
+            if args.on or args.off:
+                enabled = bool(args.on)
+                client.set_auto_top_up(dseq, enabled)
+                print(
+                    f"Auto top-up {'enabled' if enabled else 'disabled'} for deployment {label}."
+                )
+            else:
+                settings = client.get_deployment_settings(dseq)
+                if not settings:
+                    print(f"Deployment {label}: auto top-up not configured (off).")
+                else:
+                    enabled = bool(settings.get("autoTopUpEnabled", False))
+                    print(f"Deployment {label}: auto top-up {'on' if enabled else 'off'}")
+                    for key in ("estimatedTopUpAmount", "topUpFrequencyMs"):
+                        if key in settings:
+                            print(f"  {key}: {settings[key]}")
         except RuntimeError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -169,43 +169,17 @@ def _resolve_tier(arg_value: list[str] | None, env_name: str) -> list[str]:
     return [a.strip() for a in raw.split(",") if a.strip()]
 
 
-def deploy(
+def _prepare_sdl_content(
     sdl_path: str,
-    gpu: bool = False,
     image: str | None = None,
-    bid_wait: int = 60,
-    bid_wait_retry: int = 120,
     env_vars: list[str] | None = None,
-    preferred_providers: list[str] | None = None,
-    backup_providers: list[str] | None = None,
-) -> dict:
-    api_key = os.environ.get("AKASH_API_KEY")
-    if not api_key:
-        raise RuntimeError(
-            "AKASH_API_KEY environment variable not set. "
-            "Please set your API key: export AKASH_API_KEY='your-key'"
-        )
+) -> str:
+    """Read, validate, and apply image/SSH-key/env overrides to an SDL file.
 
-    client = AkashConsoleAPI(api_key)
-
-    preferred = _resolve_tier(preferred_providers, "AKASH_PROVIDERS")
-    backup = _resolve_tier(backup_providers, "AKASH_PROVIDERS_BACKUP")
-    has_allowlist = bool(preferred or backup)
-
-    _log(
-        logging.INFO,
-        f"CONFIG  sdl={sdl_path}  gpu={gpu}  image={image or '(default)'}  "
-        f"bid_wait={bid_wait}s  bid_wait_retry={bid_wait_retry}s",
-    )
-    if preferred:
-        _log(logging.INFO, f"PREFERRED_PROVIDERS ({len(preferred)}): {preferred}")
-    if backup:
-        _log(logging.INFO, f"BACKUP_PROVIDERS ({len(backup)}): {backup}")
-    if not has_allowlist:
-        _log(logging.INFO, "ALLOWED_PROVIDERS: (any — no allowlist set)")
-
-    # Step 1: Read SDL file
-    _log(logging.INFO, f"STEP 1: Reading SDL from {sdl_path}")
+    Shared by deploy() and update() so both paths transform the SDL identically.
+    Returns the final SDL string ready to send to the Console API.
+    """
+    _log(logging.INFO, f"Reading SDL from {sdl_path}")
     sdl_path_obj = Path(sdl_path)
     if not sdl_path_obj.exists():
         raise RuntimeError(f"SDL file not found: {sdl_path}")
@@ -247,10 +221,56 @@ def deploy(
         sdl_content = _inject_env_into_sdl(sdl_content, env_vars)
         _log(logging.INFO, f"Injected {len(env_vars)} env var(s) into SDL (provider-visible)")
 
+    return sdl_content
+
+
+def deploy(
+    sdl_path: str,
+    gpu: bool = False,
+    image: str | None = None,
+    bid_wait: int = 60,
+    bid_wait_retry: int = 120,
+    env_vars: list[str] | None = None,
+    preferred_providers: list[str] | None = None,
+    backup_providers: list[str] | None = None,
+    deposit: float = 5.0,
+) -> dict:
+    api_key = os.environ.get("AKASH_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "AKASH_API_KEY environment variable not set. "
+            "Please set your API key: export AKASH_API_KEY='your-key'"
+        )
+
+    client = AkashConsoleAPI(api_key)
+
+    preferred = _resolve_tier(preferred_providers, "AKASH_PROVIDERS")
+    backup = _resolve_tier(backup_providers, "AKASH_PROVIDERS_BACKUP")
+    has_allowlist = bool(preferred or backup)
+
+    _log(
+        logging.INFO,
+        f"CONFIG  sdl={sdl_path}  gpu={gpu}  image={image or '(default)'}  "
+        f"bid_wait={bid_wait}s  bid_wait_retry={bid_wait_retry}s",
+    )
+    if preferred:
+        _log(logging.INFO, f"PREFERRED_PROVIDERS ({len(preferred)}): {preferred}")
+    if backup:
+        _log(logging.INFO, f"BACKUP_PROVIDERS ({len(backup)}): {backup}")
+    if not has_allowlist:
+        _log(logging.INFO, "ALLOWED_PROVIDERS: (any — no allowlist set)")
+
+    # Step 1: Read + validate + transform SDL
+    _log(logging.INFO, "STEP 1: Preparing SDL")
+    sdl_content = _prepare_sdl_content(sdl_path, image=image, env_vars=env_vars)
+
     # Step 2: Create deployment (with stale-deployment recovery)
-    _log(logging.INFO, "STEP 2: Creating deployment via Console API...")
+    _log(
+        logging.INFO,
+        f"STEP 2: Creating deployment via Console API (escrow deposit: {deposit} USD)...",
+    )
     try:
-        deployment_response = client.create_deployment(sdl_content)
+        deployment_response = client.create_deployment(sdl_content, deposit=deposit)
     except RuntimeError as e:
         if "already exists" in str(e).lower():
             _log(
@@ -272,7 +292,7 @@ def deploy(
                 _log(logging.ERROR, f"Stale deployment cleanup failed: {cleanup_err}")
             # Retry once after cleanup
             try:
-                deployment_response = client.create_deployment(sdl_content)
+                deployment_response = client.create_deployment(sdl_content, deposit=deposit)
             except RuntimeError as retry_err:
                 _log(logging.ERROR, f"Create deployment FAILED after retry: {retry_err}")
                 raise RuntimeError(
@@ -803,6 +823,54 @@ def deploy(
         "price_denom": price_denom,
         "lease": lease_response,
     }
+
+
+def update(
+    dseq: str,
+    sdl_path: str,
+    image: str | None = None,
+    env_vars: list[str] | None = None,
+) -> dict:
+    """Update an active deployment in place with a revised SDL.
+
+    Reuses the same SDL preparation as deploy() (validation, image/SSH/env
+    overrides) then PUTs to the Console API. The DSEQ and existing lease are
+    preserved — no re-bid or new lease is created.
+    """
+    api_key = os.environ.get("AKASH_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "AKASH_API_KEY environment variable not set. "
+            "Please set your API key: export AKASH_API_KEY='your-key'"
+        )
+
+    client = AkashConsoleAPI(api_key)
+
+    _log(
+        logging.INFO,
+        f"UPDATE  dseq={dseq}  sdl={sdl_path}  image={image or '(default)'}",
+    )
+
+    # Step 1: Read + validate + transform SDL (identical to deploy).
+    _log(logging.INFO, "STEP 1: Preparing SDL")
+    sdl_content = _prepare_sdl_content(sdl_path, image=image, env_vars=env_vars)
+
+    # Step 2: Submit the in-place update.
+    _log(logging.INFO, f"STEP 2: Submitting in-place update for deployment {dseq}...")
+    try:
+        result = client.update_deployment(str(dseq), sdl_content)
+    except RuntimeError as e:
+        _log(logging.ERROR, f"Update FAILED: {e}")
+        raise RuntimeError(f"Failed to update deployment {dseq}: {e}") from e
+
+    _log(
+        logging.INFO,
+        f"Deployment {dseq} updated in place (DSEQ and lease preserved).",
+    )
+    print(f"\nDeployment {dseq} updated.")
+    print(f"Use 'just-akash status {dseq}' to verify the new revision is live.")
+
+    return {"dseq": str(dseq), "result": result}
 
 
 def deploy_main():

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -18,6 +18,7 @@ Workflow:
 
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -246,6 +247,11 @@ def deploy(
             "AKASH_API_KEY environment variable not set. "
             "Please set your API key: export AKASH_API_KEY='your-key'"
         )
+
+    # deposit is user-controlled (--deposit); reject non-finite/non-positive
+    # values before they reach json.dumps (which would emit invalid NaN/Infinity).
+    if not math.isfinite(deposit) or deposit <= 0:
+        raise RuntimeError(f"Invalid deposit {deposit!r}: must be a positive, finite USD amount.")
 
     client = AkashConsoleAPI(api_key)
 
@@ -819,7 +825,7 @@ def deploy(
     print(f"  DSEQ: {dseq}")
     print(f"  Provider: {provider}")
     print(f"  Price: {price_amount} {price_denom}")
-    print(f"\nUse 'just-akash status {dseq}' to check deployment status")
+    print(f"\nUse 'just-akash status --dseq {dseq}' to check deployment status")
 
     return {
         "dseq": dseq,
@@ -873,7 +879,7 @@ def update(
         f"Deployment {dseq} updated in place (DSEQ and lease preserved).",
     )
     print(f"\nDeployment {dseq} updated.")
-    print(f"Use 'just-akash status {dseq}' to verify the new revision is live.")
+    print(f"Use 'just-akash status --dseq {dseq}' to verify the new revision is live.")
 
     return {"dseq": str(dseq), "result": result}
 

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -196,13 +196,18 @@ def _prepare_sdl_content(
     _log(logging.INFO, "SDL validation OK")
 
     if image:
-        sdl_content = re.sub(
-            r"image:\s+[^\n]+",
-            lambda _: f"image: {image}",
+        # Anchor to the YAML `image:` key at line start (after indentation) so a
+        # comment that merely mentions "image:" can't be hijacked as the target.
+        sdl_content, n_subs = re.subn(
+            r"(?m)^(?P<indent>[ \t]*)image:[ \t]+\S[^\n]*",
+            lambda m: f"{m.group('indent')}image: {image}",
             sdl_content,
             count=1,
         )
-        _log(logging.INFO, f"Overrode image to: {image}")
+        if n_subs:
+            _log(logging.INFO, f"Overrode image to: {image}")
+        else:
+            _log(logging.WARNING, f"--image {image} set but no 'image:' key found to override")
 
     if "PLACEHOLDER_SSH_PUBKEY_B64" in sdl_content:
         import base64

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -170,7 +170,7 @@ class LeaseShellTransport(Transport):
     def _build_provider_shell_url(
         self, command: str | None = None, tty: bool = False, stdin: bool = False
     ) -> str:
-        assert self._provider_host_uri is not None
+        assert self._provider_host_uri is not None  # noqa: S101 type-narrowing
         dseq = self._config.dseq
         qs_parts = [
             "podIndex=0",
@@ -187,7 +187,7 @@ class LeaseShellTransport(Transport):
     def _build_shell_url_sh_c(
         self, shell_command: str, tty: bool = False, stdin: bool = False
     ) -> str:
-        assert self._provider_host_uri is not None
+        assert self._provider_host_uri is not None  # noqa: S101 type-narrowing
         dseq = self._config.dseq
         qs_parts = [
             "podIndex=0",
@@ -204,7 +204,7 @@ class LeaseShellTransport(Transport):
     def _build_logs_url(
         self, follow: bool = False, tail: int = 100, service: str | None = None
     ) -> str:
-        assert self._provider_host_uri is not None
+        assert self._provider_host_uri is not None  # noqa: S101 type-narrowing
         dseq = self._config.dseq
         qs_parts = [
             f"follow={'true' if follow else 'false'}",
@@ -216,7 +216,7 @@ class LeaseShellTransport(Transport):
         return f"{self._provider_host_uri}/lease/{dseq}/1/1/logs?{qs}"
 
     def _build_events_url(self) -> str:
-        assert self._provider_host_uri is not None
+        assert self._provider_host_uri is not None  # noqa: S101 type-narrowing
         dseq = self._config.dseq
         return f"{self._provider_host_uri}/lease/{dseq}/1/1/kubeevents"
 
@@ -579,7 +579,7 @@ class LeaseShellTransport(Transport):
                             }
                         )
                     )
-                except Exception:
+                except Exception:  # noqa: S110 best-effort send inside SIGINT handler; logging is unsafe here
                     pass
 
             try:
@@ -608,7 +608,7 @@ class LeaseShellTransport(Transport):
                             )
                         )
                         _last_size[0] = new_size
-                    except Exception:
+                    except Exception:  # noqa: S110 best-effort resize inside SIGWINCH handler; logging is unsafe here
                         pass
 
             original_sigint = signal.signal(signal.SIGINT, _sigint_handler)

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -711,11 +711,16 @@ class LeaseShellTransport(Transport):
         kind = involved.get("kind", "")
         name = involved.get("name", "")
         target = f"{kind}/{name}".strip("/")
-        message = obj.get("message") or obj.get("note") or ""
+        # Resolve message/note by presence, not truthiness — a numeric 0 is a
+        # valid message and must not be dropped.
+        message = obj.get("message")
+        if message is None:
+            message = obj.get("note")
+        message = "" if message is None else str(message)
         ts = obj.get("lastTimestamp") or obj.get("firstTimestamp") or obj.get("eventTime") or ""
-        parts = [
-            str(p) for p in (ts, obj.get("type", ""), obj.get("reason", ""), target, message) if p
-        ]
+        parts = [str(p) for p in (ts, obj.get("type", ""), obj.get("reason", ""), target) if p]
+        if message != "":
+            parts.append(message)
         return "  ".join(parts) if parts else text
 
     def _stream(self, provider_url: str, scope: list[str], formatter, recv_timeout: float) -> None:
@@ -748,10 +753,13 @@ class LeaseShellTransport(Transport):
                     continue
                 if frame is None:
                     continue
+                # Every received data frame maps to one output line. Do NOT skip
+                # empty lines — a blank line is real log output and dropping it
+                # would make the stream an unfaithful copy. (ping/pong control
+                # frames already decode to None above and never reach here.)
                 line = formatter(frame)
-                if line:
-                    sys.stdout.write(line + "\n")
-                    sys.stdout.flush()
+                sys.stdout.write(line + "\n")
+                sys.stdout.flush()
 
     def stream_logs(
         self, follow: bool = False, tail: int = 100, service: str | None = None

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -85,14 +85,21 @@ class LeaseShellTransport(Transport):
             )
         return self._api_client
 
-    def _fetch_jwt(self, ttl: int = 3600) -> str:
+    def _fetch_jwt(self, ttl: int = 3600, scope: list[str] | None = None) -> str:
         if self._provider_address:
             return self._get_api_client().create_jwt_with_provider(
-                self._config.dseq, self._provider_address, ttl=ttl
+                self._config.dseq, self._provider_address, ttl=ttl, scope=scope
             )
-        return self._get_api_client().create_jwt(self._config.dseq, ttl=ttl)
+        return self._get_api_client().create_jwt(self._config.dseq, ttl=ttl, scope=scope)
 
-    def _extract_provider_info(self) -> tuple[str, str]:
+    def _resolve_provider(self) -> str:
+        """Resolve the provider address + hostUri from lease data.
+
+        Sets ``self._provider_address`` and ``self._provider_host_uri`` and
+        returns the hostUri. Unlike ``_extract_provider_info`` this does NOT
+        require a service name — used by streaming endpoints (logs, events)
+        that operate at the lease level.
+        """
         leases = self._config.deployment.get("leases", [])
         if not leases or not isinstance(leases, list):
             raise RuntimeError(
@@ -110,7 +117,10 @@ class LeaseShellTransport(Transport):
         if provider_addr:
             self._provider_address = provider_addr
 
-        host_uri = self._resolve_host_uri(lease, provider_addr)
+        return self._resolve_host_uri(lease, provider_addr)
+
+    def _extract_provider_info(self) -> tuple[str, str]:
+        host_uri = self._resolve_provider()
 
         service = self._config.service_name or self._infer_service()
         if not service:
@@ -190,6 +200,25 @@ class LeaseShellTransport(Transport):
         ]
         qs = "&".join(qs_parts)
         return f"{self._provider_host_uri}/lease/{dseq}/1/1/shell?{qs}"
+
+    def _build_logs_url(
+        self, follow: bool = False, tail: int = 100, service: str | None = None
+    ) -> str:
+        assert self._provider_host_uri is not None
+        dseq = self._config.dseq
+        qs_parts = [
+            f"follow={'true' if follow else 'false'}",
+            f"tail={int(tail)}",
+        ]
+        if service:
+            qs_parts.append(f"service={urllib.parse.quote(service, safe='')}")
+        qs = "&".join(qs_parts)
+        return f"{self._provider_host_uri}/lease/{dseq}/1/1/logs?{qs}"
+
+    def _build_events_url(self) -> str:
+        assert self._provider_host_uri is not None
+        dseq = self._config.dseq
+        return f"{self._provider_host_uri}/lease/{dseq}/1/1/kubeevents"
 
     def _build_proxy_connect_msg(
         self, shell_path: str, jwt: str, stdin_data: str | None = None
@@ -641,6 +670,109 @@ class LeaseShellTransport(Transport):
                 return
             except TimeoutError:
                 pass
+
+    @staticmethod
+    def _format_log_message(raw: bytes) -> str:
+        """Render one streamed log frame as a single output line.
+
+        The provider streams either raw text lines or JSON ServiceLogMessages
+        (``{"name": <service>, "message": <line>}``). Handle both: JSON dicts
+        become ``[service] message``; everything else passes through verbatim.
+        """
+        text = raw.decode("utf-8", errors="replace")
+        stripped = text.strip()
+        if stripped.startswith("{"):
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                obj = None
+            if isinstance(obj, dict):
+                name = obj.get("name") or obj.get("service") or ""
+                msg = obj.get("message")
+                if msg is None:
+                    msg = obj.get("msg", "")
+                line = f"[{name}] {msg}" if name else str(msg)
+                return line.rstrip("\n")
+        return text.rstrip("\n")
+
+    @staticmethod
+    def _format_event_message(raw: bytes) -> str:
+        """Render one streamed Kubernetes event frame as a single line."""
+        text = raw.decode("utf-8", errors="replace").strip()
+        try:
+            obj = json.loads(text)
+        except json.JSONDecodeError:
+            return text
+        if not isinstance(obj, dict):
+            return text
+        involved = obj.get("involvedObject") or obj.get("object") or {}
+        if not isinstance(involved, dict):
+            involved = {}
+        kind = involved.get("kind", "")
+        name = involved.get("name", "")
+        target = f"{kind}/{name}".strip("/")
+        message = obj.get("message") or obj.get("note") or ""
+        ts = obj.get("lastTimestamp") or obj.get("firstTimestamp") or obj.get("eventTime") or ""
+        parts = [
+            str(p) for p in (ts, obj.get("type", ""), obj.get("reason", ""), target, message) if p
+        ]
+        return "  ".join(parts) if parts else text
+
+    def _stream(self, provider_url: str, scope: list[str], formatter, recv_timeout: float) -> None:
+        """Open a provider-proxy WebSocket and print each frame via ``formatter``.
+
+        Runs until the server closes the stream (non-follow / snapshot) or the
+        user interrupts (Ctrl-C). Read-only: no stdin is sent. Callers must have
+        already called ``_resolve_provider`` so the proxy URL embeds the host.
+        """
+        jwt = self._fetch_jwt(scope=scope)
+        proxy_url = self._get_proxy_ws_url()
+        connect_msg = self._build_proxy_connect_msg(provider_url, jwt)
+        ssl_ctx = ssl.create_default_context()
+
+        with connect(
+            proxy_url,
+            ssl=ssl_ctx,
+            compression=None,
+            open_timeout=30,
+            ping_interval=30,
+            ping_timeout=20,
+        ) as ws:
+            ws.send(connect_msg)
+            while True:
+                try:
+                    frame = self._recv_proxy_message(ws, timeout=recv_timeout)
+                except (ConnectionClosedOK, ConnectionClosedError):
+                    return
+                except TimeoutError:
+                    continue
+                if frame is None:
+                    continue
+                line = formatter(frame)
+                if line:
+                    sys.stdout.write(line + "\n")
+                    sys.stdout.flush()
+
+    def stream_logs(
+        self, follow: bool = False, tail: int = 100, service: str | None = None
+    ) -> None:
+        """Stream container logs for the lease via the provider-proxy.
+
+        With ``follow=True`` the stream stays open until interrupted; otherwise
+        it prints the last ``tail`` lines and returns. ``service`` filters to a
+        single service (default: all services in the lease).
+        """
+        self._resolve_provider()
+        url = self._build_logs_url(follow=follow, tail=tail, service=service)
+        # Follow streams indefinitely between lines, so use a long per-recv
+        # timeout and just loop on timeout; a snapshot closes on its own.
+        self._stream(url, ["logs"], self._format_log_message, recv_timeout=300)
+
+    def stream_events(self) -> None:
+        """Stream Kubernetes events for the lease via the provider-proxy."""
+        self._resolve_provider()
+        url = self._build_events_url()
+        self._stream(url, ["events"], self._format_event_message, recv_timeout=300)
 
     def validate(self) -> bool:
         leases = self._config.deployment.get("leases", [])

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -690,7 +690,11 @@ class LeaseShellTransport(Transport):
                 name = obj.get("name") or obj.get("service") or ""
                 msg = obj.get("message")
                 if msg is None:
-                    msg = obj.get("msg", "")
+                    msg = obj.get("msg")
+                if msg is None:
+                    # Structured JSON with no recognizable message field — surface
+                    # the raw payload rather than collapsing it to a blank line.
+                    return stripped
                 line = f"[{name}] {msg}" if name else str(msg)
                 return line.rstrip("\n")
         return text.rstrip("\n")

--- a/just_akash/transport/ssh.py
+++ b/just_akash/transport/ssh.py
@@ -35,8 +35,8 @@ class SSHTransport(Transport):
 
     def exec(self, command: str) -> int:
         """Run command via SSH subprocess; return exit code."""
-        assert self._ssh_info is not None, "Call prepare() first"
-        assert self._key_path is not None, "Call prepare() first"
+        assert self._ssh_info is not None, "Call prepare() first"  # noqa: S101 type-narrowing
+        assert self._key_path is not None, "Call prepare() first"  # noqa: S101 type-narrowing
         ssh_cmd = _build_ssh_cmd(self._ssh_info, self._key_path)
         ssh_cmd.append(command)
         result = subprocess.run(ssh_cmd, text=True)
@@ -44,8 +44,8 @@ class SSHTransport(Transport):
 
     def inject(self, remote_path: str, content: str) -> None:
         """Inject secrets via SSH (mkdir, cat, chmod)."""
-        assert self._ssh_info is not None, "Call prepare() first"
-        assert self._key_path is not None, "Call prepare() first"
+        assert self._ssh_info is not None, "Call prepare() first"  # noqa: S101 type-narrowing
+        assert self._key_path is not None, "Call prepare() first"  # noqa: S101 type-narrowing
         ssh_cmd = _build_ssh_cmd(self._ssh_info, self._key_path)
         # mkdir -p
         subprocess.run(
@@ -65,8 +65,8 @@ class SSHTransport(Transport):
 
     def connect(self) -> None:
         """Interactive SSH shell (replaces process via os.execvp — never returns)."""
-        assert self._ssh_info is not None, "Call prepare() first"
-        assert self._key_path is not None, "Call prepare() first"
+        assert self._ssh_info is not None, "Call prepare() first"  # noqa: S101 type-narrowing
+        assert self._key_path is not None, "Call prepare() first"  # noqa: S101 type-narrowing
         ssh_cmd = _build_ssh_cmd(self._ssh_info, self._key_path)
         os.execvp("ssh", ssh_cmd)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,24 @@ target-version = "py310"
 line-length = 99
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM"]
+select = ["E", "F", "I", "UP", "B", "SIM", "S"]
+ignore = [
+    # This CLI shells out to `ssh` by design: it builds argv lists (never
+    # shell=True — S602 stays enabled to enforce that) and resolves `ssh` from
+    # PATH for portability. These three bandit rules fire on every
+    # subprocess/exec regardless of safety, so they are low-signal here.
+    "S603", # subprocess call — flagged on argv-list calls with no shell
+    "S606", # start a process without a shell (this is the *secure* choice)
+    "S607", # partial executable path (`ssh`/`git` from PATH is intentional)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Test and e2e code: assert-based tests (S101), hardcoded test creds (S105) and
+# /tmp paths (S108), and shell-based test orchestration (S602) are expected and
+# are not part of the shipped attack surface.
+"tests/**" = ["S"]
+"just_akash/test_*.py" = ["S"]
+"just_akash/_e2e.py" = ["S"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,15 @@ line-length = 99
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "S"]
-ignore = [
-    # This CLI shells out to `ssh` by design: it builds argv lists (never
-    # shell=True — S602 stays enabled to enforce that) and resolves `ssh` from
-    # PATH for portability. These three bandit rules fire on every
-    # subprocess/exec regardless of safety, so they are low-signal here.
-    "S603", # subprocess call — flagged on argv-list calls with no shell
-    "S606", # start a process without a shell (this is the *secure* choice)
-    "S607", # partial executable path (`ssh`/`git` from PATH is intentional)
-]
 
 [tool.ruff.lint.per-file-ignores]
+# Modules that shell out to `ssh` by design: they build argv lists (never
+# shell=True — S602 stays enabled everywhere to enforce that) and resolve `ssh`
+# from PATH for portability. Scope S603/S606/S607 to just these files so a new
+# unsafe subprocess/exec elsewhere still fails CI.
+"just_akash/api.py" = ["S603", "S606", "S607"]
+"just_akash/cli.py" = ["S603", "S606", "S607"]
+"just_akash/transport/ssh.py" = ["S603", "S606", "S607"]
 # Test and e2e code: assert-based tests (S101), hardcoded test creds (S105) and
 # /tmp paths (S108), and shell-based test orchestration (S602) are expected and
 # are not part of the shipped attack surface.

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -1727,7 +1727,7 @@ services:
 
         client = AkashConsoleAPI("key")
         monkeypatch.setattr(
-            client, "create_deployment", lambda _: {"dseq": "123", "manifest": "abc"}
+            client, "create_deployment", lambda *a, **k: {"dseq": "123", "manifest": "abc"}
         )
         monkeypatch.setattr(
             client, "get_bids", lambda _: [{"id": {"provider": "p"}, "price": {"amount": 10}}]
@@ -1762,7 +1762,7 @@ services:
 
         client = AkashConsoleAPI("key")
         monkeypatch.setattr(
-            client, "create_deployment", lambda _: {"dseq": "123", "manifest": "abc"}
+            client, "create_deployment", lambda *a, **k: {"dseq": "123", "manifest": "abc"}
         )
         monkeypatch.setattr(
             client, "get_bids", lambda _: [{"id": {"provider": "p"}, "price": {"amount": 10}}]
@@ -1842,7 +1842,7 @@ services:
 
         client = AkashConsoleAPI("key")
         monkeypatch.setattr(
-            client, "create_deployment", lambda _: {"dseq": "123", "manifest": "abc"}
+            client, "create_deployment", lambda *a, **k: {"dseq": "123", "manifest": "abc"}
         )
         monkeypatch.setattr(
             client, "get_bids", lambda _: [{"id": {"provider": "p"}, "price": {"amount": 10}}]
@@ -1936,7 +1936,7 @@ class TestBidPollingZeroTimeout:
 
         client = AkashConsoleAPI("key")
         monkeypatch.setattr(
-            client, "create_deployment", lambda _: {"dseq": "123", "manifest": "abc"}
+            client, "create_deployment", lambda *a, **k: {"dseq": "123", "manifest": "abc"}
         )
         monkeypatch.setattr(client, "get_bids", lambda _: [])
 
@@ -1970,7 +1970,7 @@ services:
 
         client = AkashConsoleAPI("key")
         monkeypatch.setattr(
-            client, "create_deployment", lambda _: {"dseq": "123", "manifest": "abc"}
+            client, "create_deployment", lambda *a, **k: {"dseq": "123", "manifest": "abc"}
         )
 
         with patch("just_akash.deploy.AkashConsoleAPI", return_value=client):

--- a/tests/test_api_extensions.py
+++ b/tests/test_api_extensions.py
@@ -166,6 +166,41 @@ class TestSetAutoTopUp:
         mock_create.assert_called_once_with("12345", True)
         mock_update.assert_not_called()
 
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_upsert_creates_when_settings_endpoint_returns_data_null(self, mock_req):
+        # A deployment with no settings yet can be reported as {"data": null}
+        # (the key is present, the value is None) rather than a 404 or an empty
+        # object. get_deployment_settings unwraps data=None to the *raw wrapper*
+        # {"data": None}, which is truthy, so set_auto_top_up's `if existing:`
+        # routes to PATCH (update an existing record) instead of POST (create).
+        # The PATCH targets a settings record that does not exist -> wrong verb,
+        # and on a real server a 404. The upsert must CREATE here.
+        def _route(method, endpoint, data=None):
+            if method == "GET":
+                return {"data": None}  # "no settings yet"
+            return {"data": {"autoTopUpEnabled": True}}
+
+        mock_req.side_effect = _route
+        client = AkashConsoleAPI("key")
+        client.set_auto_top_up("12345", True)
+        methods = [call.args[0] for call in mock_req.call_args_list]
+        # After the GET, the upsert must POST (create), never PATCH (update).
+        assert "PATCH" not in methods, f"upsert wrongly PATCHed non-existent settings: {methods}"
+        assert "POST" in methods
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_settings_data_null_returns_empty_dict_not_wrapper(self, mock_req):
+        # When the settings response is {"data": null}, get_deployment_settings
+        # must return {} ("unset") so callers' truthiness checks behave. Instead
+        # it returns the raw wrapper {"data": None} because data is None (not a
+        # dict) and the fallback hands back the whole response.
+        mock_req.return_value = {"data": None}
+        client = AkashConsoleAPI("key")
+        result = client.get_deployment_settings("12345")
+        assert result == {}, f"expected {{}} for data=null, got {result!r}"
+        # And the wrapper must not leak through as a truthy "settings exist".
+        assert not result
+
 
 # ── JWT scope parameter ──────────────────────────────────────────────
 

--- a/tests/test_api_extensions.py
+++ b/tests/test_api_extensions.py
@@ -99,6 +99,30 @@ class TestDeploymentSettings:
             client.get_deployment_settings("12345")
 
     @patch.object(AkashConsoleAPI, "_request")
+    def test_get_settings_non_404_with_404_substring_in_dseq_must_reraise(self, mock_req):
+        # A genuine HTTP 400 whose body happens to contain "404" as a substring
+        # of a dseq (e.g. 40400) must NOT be misread as "no settings yet". The
+        # 404-detection uses a naive `"404" in str(e)` substring test, so this
+        # error is silently swallowed and returned as {} instead of re-raising.
+        mock_req.side_effect = RuntimeError("API Error (400): invalid dseq 40400")
+        client = AkashConsoleAPI("key")
+        with pytest.raises(RuntimeError, match="400"):
+            client.get_deployment_settings("40400")
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_get_settings_500_containing_not_found_phrase_must_reraise(self, mock_req):
+        # A real server error (HTTP 500) whose body contains the words
+        # "not found" (e.g. an internal lookup failure) is a hard failure that
+        # must surface, not be treated as "settings unset". The casing-insensitive
+        # "not found" substring check wrongly swallows it as {}.
+        mock_req.side_effect = RuntimeError(
+            "API Error (500): deployment record Not Found in escrow ledger"
+        )
+        client = AkashConsoleAPI("key")
+        with pytest.raises(RuntimeError, match="500"):
+            client.get_deployment_settings("12345")
+
+    @patch.object(AkashConsoleAPI, "_request")
     def test_create_settings_body(self, mock_req):
         mock_req.return_value = {"data": {"autoTopUpEnabled": True}}
         client = AkashConsoleAPI("key")

--- a/tests/test_api_extensions.py
+++ b/tests/test_api_extensions.py
@@ -1,0 +1,182 @@
+"""Tests for the v1.6 API-coverage additions to just_akash.api.
+
+Covers: update_deployment (PUT), deposit_deployment, deployment-settings
+(GET/POST/PATCH + set_auto_top_up upsert), and the JWT scope parameter.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from just_akash.api import AkashConsoleAPI
+
+# ── update_deployment (PUT /v1/deployments/{dseq}) ───────────────────
+
+
+class TestUpdateDeployment:
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_update_sends_put_with_sdl(self, mock_req):
+        mock_req.return_value = {"data": {"dseq": "12345", "state": "active"}}
+        client = AkashConsoleAPI("key")
+        result = client.update_deployment("12345", "sdl-body")
+        mock_req.assert_called_once_with(
+            "PUT", "/v1/deployments/12345", {"data": {"sdl": "sdl-body"}}
+        )
+        assert result["dseq"] == "12345"
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_update_unwraps_bare_dict(self, mock_req):
+        mock_req.return_value = {"dseq": "999", "state": "active"}
+        client = AkashConsoleAPI("key")
+        assert client.update_deployment("999", "x")["dseq"] == "999"
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_update_non_dict_response(self, mock_req):
+        mock_req.return_value = ["unexpected"]
+        client = AkashConsoleAPI("key")
+        assert client.update_deployment("1", "x") == {}
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_update_coerces_dseq_to_str(self, mock_req):
+        mock_req.return_value = {"data": {}}
+        client = AkashConsoleAPI("key")
+        client.update_deployment(12345, "x")  # type: ignore[arg-type]
+        assert mock_req.call_args[0][1] == "/v1/deployments/12345"
+
+
+# ── deposit_deployment (POST /v1/deposit-deployment) ─────────────────
+
+
+class TestDepositDeployment:
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_deposit_body_and_path(self, mock_req):
+        mock_req.return_value = {"data": {"dseq": "12345"}}
+        client = AkashConsoleAPI("key")
+        client.deposit_deployment("12345", 0.5)
+        mock_req.assert_called_once_with(
+            "POST", "/v1/deposit-deployment", {"data": {"dseq": "12345", "deposit": 0.5}}
+        )
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_deposit_coerces_dseq_to_str(self, mock_req):
+        mock_req.return_value = {"data": {}}
+        client = AkashConsoleAPI("key")
+        client.deposit_deployment(12345, 2.0)  # type: ignore[arg-type]
+        body = mock_req.call_args[0][2]
+        assert body["data"]["dseq"] == "12345"
+        assert body["data"]["deposit"] == 2.0
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_deposit_non_dict_response(self, mock_req):
+        mock_req.return_value = None
+        client = AkashConsoleAPI("key")
+        assert client.deposit_deployment("1", 1.0) == {}
+
+
+# ── deployment-settings (auto top-up) ────────────────────────────────
+
+
+class TestDeploymentSettings:
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_get_settings_path(self, mock_req):
+        mock_req.return_value = {"data": {"autoTopUpEnabled": True}}
+        client = AkashConsoleAPI("key")
+        result = client.get_deployment_settings("12345")
+        mock_req.assert_called_once_with("GET", "/v2/deployment-settings/12345")
+        assert result["autoTopUpEnabled"] is True
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_get_settings_404_returns_empty(self, mock_req):
+        mock_req.side_effect = RuntimeError("API Error (404): not found")
+        client = AkashConsoleAPI("key")
+        assert client.get_deployment_settings("12345") == {}
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_get_settings_other_error_reraises(self, mock_req):
+        mock_req.side_effect = RuntimeError("API Error (500): boom")
+        client = AkashConsoleAPI("key")
+        with pytest.raises(RuntimeError, match="500"):
+            client.get_deployment_settings("12345")
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_create_settings_body(self, mock_req):
+        mock_req.return_value = {"data": {"autoTopUpEnabled": True}}
+        client = AkashConsoleAPI("key")
+        client.create_deployment_settings("12345", True)
+        mock_req.assert_called_once_with(
+            "POST",
+            "/v2/deployment-settings",
+            {"data": {"dseq": "12345", "autoTopUpEnabled": True}},
+        )
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_update_settings_body_and_path(self, mock_req):
+        mock_req.return_value = {"data": {"autoTopUpEnabled": False}}
+        client = AkashConsoleAPI("key")
+        client.update_deployment_settings("12345", False)
+        mock_req.assert_called_once_with(
+            "PATCH",
+            "/v2/deployment-settings/12345",
+            {"data": {"autoTopUpEnabled": False}},
+        )
+
+
+class TestSetAutoTopUp:
+    @patch.object(AkashConsoleAPI, "update_deployment_settings")
+    @patch.object(AkashConsoleAPI, "create_deployment_settings")
+    @patch.object(AkashConsoleAPI, "get_deployment_settings")
+    def test_upsert_patches_when_settings_exist(self, mock_get, mock_create, mock_update):
+        mock_get.return_value = {"autoTopUpEnabled": False}
+        client = AkashConsoleAPI("key")
+        client.set_auto_top_up("12345", True)
+        mock_update.assert_called_once_with("12345", True)
+        mock_create.assert_not_called()
+
+    @patch.object(AkashConsoleAPI, "update_deployment_settings")
+    @patch.object(AkashConsoleAPI, "create_deployment_settings")
+    @patch.object(AkashConsoleAPI, "get_deployment_settings")
+    def test_upsert_creates_when_no_settings(self, mock_get, mock_create, mock_update):
+        mock_get.return_value = {}
+        client = AkashConsoleAPI("key")
+        client.set_auto_top_up("12345", True)
+        mock_create.assert_called_once_with("12345", True)
+        mock_update.assert_not_called()
+
+
+# ── JWT scope parameter ──────────────────────────────────────────────
+
+
+class TestJwtScope:
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_create_jwt_defaults_to_shell(self, mock_req):
+        mock_req.return_value = {"data": {"token": "jwt"}}
+        client = AkashConsoleAPI("key")
+        assert client.create_jwt("12345") == "jwt"
+        body = mock_req.call_args[0][2]
+        assert body["data"]["leases"]["scope"] == ["shell"]
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_create_jwt_custom_scope(self, mock_req):
+        mock_req.return_value = {"data": {"token": "jwt"}}
+        client = AkashConsoleAPI("key")
+        client.create_jwt("12345", scope=["logs"])
+        body = mock_req.call_args[0][2]
+        assert body["data"]["leases"]["scope"] == ["logs"]
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_create_jwt_with_provider_custom_scope(self, mock_req):
+        mock_req.return_value = {"data": {"token": "jwt"}}
+        client = AkashConsoleAPI("key")
+        client.create_jwt_with_provider("12345", "akash1prov", scope=["events"])
+        body = mock_req.call_args[0][2]
+        perm = body["data"]["leases"]["permissions"][0]
+        assert perm["provider"] == "akash1prov"
+        assert perm["scope"] == ["events"]
+
+    @patch.object(AkashConsoleAPI, "_request")
+    def test_create_jwt_with_provider_defaults_to_shell(self, mock_req):
+        mock_req.return_value = {"data": {"token": "jwt"}}
+        client = AkashConsoleAPI("key")
+        client.create_jwt_with_provider("12345", "akash1prov")
+        perm = mock_req.call_args[0][2]["data"]["leases"]["permissions"][0]
+        assert perm["scope"] == ["shell"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,6 +308,7 @@ class TestCliDeployPassesArgs:
             env_vars=[],
             preferred_providers=None,
             backup_providers=None,
+            deposit=5.0,
         )
 
     @patch("just_akash.deploy.deploy")

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -1,9 +1,11 @@
 """Tests for the v1.6 CLI subcommands: update, logs, events, add-funds, auto-topup."""
 
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+from just_akash.cli import _enrich_deployment_with_provider
 
 
 def _run_cli(monkeypatch, args):
@@ -274,3 +276,33 @@ class TestCliAutoTopup:
         assert "escrow service unavailable" in err
         # The set call was actually attempted (we're testing the set-path, not show).
         client.set_auto_top_up.assert_called_once_with("12345", True)
+
+
+class TestEnrichProviderHostUri:
+    def test_backfills_blank_hosturi_from_registry(self):
+        client = MagicMock()
+        client.get_provider.return_value = {"hostUri": "https://p.example:8443"}
+        dep = {"leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": ""}}]}
+        out = _enrich_deployment_with_provider(client, dep)
+        assert out["leases"][0]["provider"]["hostUri"] == "https://p.example:8443"
+        client.get_provider.assert_called_once_with("akash1p")
+
+    def test_keeps_existing_nonblank_hosturi(self):
+        client = MagicMock()
+        dep = {"leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": "https://keep"}}]}
+        out = _enrich_deployment_with_provider(client, dep)
+        assert out["leases"][0]["provider"]["hostUri"] == "https://keep"
+        client.get_provider.assert_not_called()
+
+    def test_tolerates_non_list_leases(self):
+        client = MagicMock()
+        assert _enrich_deployment_with_provider(client, {"leases": None}) == {"leases": None}
+        client.get_provider.assert_not_called()
+
+    def test_skips_non_dict_lease_entries(self):
+        client = MagicMock()
+        client.get_provider.return_value = {"hostUri": "https://p"}
+        dep = {"leases": ["weird", {"id": {"provider": "akash1p"}}]}
+        out = _enrich_deployment_with_provider(client, dep)
+        client.get_provider.assert_called_once_with("akash1p")
+        assert out["leases"][1]["provider"]["hostUri"] == "https://p"

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -188,6 +188,23 @@ class TestCliAutoTopup:
         assert "auto top-up on" in out
         assert "topUpFrequencyMs" in out
 
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_show_does_not_lie_when_enabled_is_string_false(
+        self, MockAPI, mock_tag, monkeypatch, capsys
+    ):
+        # If the API returns autoTopUpEnabled as the *string* "false" (a real
+        # JSON-vs-bool mismatch some servers emit), the display computes
+        # bool("false") == True and prints "auto top-up on" — the opposite of
+        # the truth. The shown state must reflect the disabled value.
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        client.get_deployment_settings.return_value = {"autoTopUpEnabled": "false"}
+        _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345"])
+        out = capsys.readouterr().out
+        assert "auto top-up off" in out
+        assert "auto top-up on" not in out
+
     def test_on_and_off_mutually_exclusive(self, monkeypatch):
         with pytest.raises(SystemExit) as e:
             _run_cli(

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -137,6 +137,29 @@ class TestCliAddFunds:
 
     @patch("just_akash.api._get_tag", return_value="")
     @patch("just_akash.api.AkashConsoleAPI")
+    def test_nan_deposit_does_not_bypass_minimum_guard(
+        self, MockAPI, mock_tag, monkeypatch, capsys
+    ):
+        # argparse `type=float` accepts "nan" -> float('nan'). The minimum-deposit
+        # guard is `if args.deposit < 0.5`, but `nan < 0.5` is False, so NaN slips
+        # past the guard and is forwarded to deposit_deployment. From there it is
+        # serialized as the bare token `NaN` in the request body
+        # ({"deposit": NaN}), which is NOT valid JSON per RFC 8259 and a strict
+        # Console API parser rejects. A NaN deposit is a nonsensical amount that
+        # the guard exists to catch; it must be rejected (exit 1) and never reach
+        # the API.
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        with pytest.raises(SystemExit) as e:
+            _run_cli(
+                monkeypatch,
+                ["just-akash", "add-funds", "--dseq", "12345", "--deposit", "nan", "-y"],
+            )
+        assert e.value.code == 1
+        client.deposit_deployment.assert_not_called()
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
     def test_confirmed_deposits(self, MockAPI, mock_tag, monkeypatch, capsys):
         monkeypatch.setenv("AKASH_API_KEY", "k")
         client = MockAPI.return_value

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -253,3 +253,24 @@ class TestCliAutoTopup:
                 ["just-akash", "auto-topup", "--dseq", "12345", "--on", "--off"],
             )
         assert e.value.code == 2
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_set_path_api_error_exits_1_cleanly(self, MockAPI, mock_tag, monkeypatch, capsys):
+        # The set-path of auto-topup (--on/--off) calls set_auto_top_up, which can
+        # raise RuntimeError on a real server failure (e.g. the upsert's PATCH/POST
+        # hits an escrow-service 500). That must surface as a friendly stderr
+        # message + exit 1, never an uncaught traceback. The existing tests only
+        # exercise the success path; this locks down the failure path.
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        client.set_auto_top_up.side_effect = RuntimeError(
+            "API Error (500): escrow service unavailable"
+        )
+        with pytest.raises(SystemExit) as e:
+            _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345", "--on"])
+        assert e.value.code == 1
+        err = capsys.readouterr().err
+        assert "escrow service unavailable" in err
+        # The set call was actually attempted (we're testing the set-path, not show).
+        client.set_auto_top_up.assert_called_once_with("12345", True)

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -100,6 +100,16 @@ class TestCliLogs:
         assert e.value.code == 1
         assert "provider resolution failed mid-stream" in capsys.readouterr().err
 
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_logs_negative_tail_exits_1(self, MockAPI, mock_make, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(SystemExit) as e:
+            _run_cli(monkeypatch, ["just-akash", "logs", "--dseq", "12345", "--tail", "-5"])
+        assert e.value.code == 1
+        assert "--tail" in capsys.readouterr().err
+        mock_make.return_value.stream_logs.assert_not_called()
+
 
 # ── events ───────────────────────────────────────────────────────────
 

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -1,0 +1,197 @@
+"""Tests for the v1.6 CLI subcommands: update, logs, events, add-funds, auto-topup."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_cli(monkeypatch, args):
+    monkeypatch.setattr(sys, "argv", args)
+    from just_akash.cli import main
+
+    return main()
+
+
+# ── update ───────────────────────────────────────────────────────────
+
+
+class TestCliUpdate:
+    @patch("just_akash.deploy.update")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_update_success(self, MockAPI, mock_update, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(SystemExit) as e:
+            _run_cli(
+                monkeypatch,
+                ["just-akash", "update", "--dseq", "12345", "--sdl", "x.yaml", "--image", "img:2"],
+            )
+        assert e.value.code == 0
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["dseq"] == "12345"
+        assert kwargs["sdl_path"] == "x.yaml"
+        assert kwargs["image"] == "img:2"
+
+    @patch("just_akash.deploy.update", side_effect=RuntimeError("boom"))
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_update_failure_exits_1(self, MockAPI, mock_update, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(SystemExit) as e:
+            _run_cli(monkeypatch, ["just-akash", "update", "--dseq", "12345", "--sdl", "x.yaml"])
+        assert e.value.code == 1
+        assert "boom" in capsys.readouterr().err
+
+    def test_update_requires_sdl(self, monkeypatch):
+        # --sdl is required; argparse exits 2 without it.
+        with pytest.raises(SystemExit) as e:
+            _run_cli(monkeypatch, ["just-akash", "update", "--dseq", "12345"])
+        assert e.value.code == 2
+
+
+# ── logs ─────────────────────────────────────────────────────────────
+
+
+class TestCliLogs:
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_logs_calls_stream_with_args(self, MockAPI, mock_make, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        _run_cli(
+            monkeypatch,
+            ["just-akash", "logs", "--dseq", "12345", "-f", "--tail", "20", "--service", "web"],
+        )
+        transport.stream_logs.assert_called_once_with(follow=True, tail=20, service="web")
+
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_logs_defaults(self, MockAPI, mock_make, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        _run_cli(monkeypatch, ["just-akash", "logs", "--dseq", "12345"])
+        transport.stream_logs.assert_called_once_with(follow=False, tail=100, service=None)
+
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_logs_keyboardinterrupt_is_clean(self, MockAPI, mock_make, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        transport.stream_logs.side_effect = KeyboardInterrupt()
+        # Must not propagate KeyboardInterrupt.
+        _run_cli(monkeypatch, ["just-akash", "logs", "--dseq", "12345"])
+
+
+# ── events ───────────────────────────────────────────────────────────
+
+
+class TestCliEvents:
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_events_calls_stream(self, MockAPI, mock_make, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        _run_cli(monkeypatch, ["just-akash", "events", "--dseq", "12345"])
+        transport.stream_events.assert_called_once_with()
+
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_events_keyboardinterrupt_is_clean(self, MockAPI, mock_make, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        transport.stream_events.side_effect = KeyboardInterrupt()
+        _run_cli(monkeypatch, ["just-akash", "events", "--dseq", "12345"])
+
+
+# ── add-funds ────────────────────────────────────────────────────────
+
+
+class TestCliAddFunds:
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_below_minimum_exits_1(self, MockAPI, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(SystemExit) as e:
+            _run_cli(
+                monkeypatch,
+                ["just-akash", "add-funds", "--dseq", "12345", "--deposit", "0.1"],
+            )
+        assert e.value.code == 1
+        assert "minimum" in capsys.readouterr().err.lower()
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_confirmed_deposits(self, MockAPI, mock_tag, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        _run_cli(
+            monkeypatch,
+            ["just-akash", "add-funds", "--dseq", "12345", "--deposit", "1.5", "-y"],
+        )
+        client.deposit_deployment.assert_called_once_with("12345", 1.5)
+        assert "Added 1.5 USD" in capsys.readouterr().out
+
+    @patch("just_akash.api._confirm", return_value=False)
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_cancelled_does_not_deposit(
+        self, MockAPI, mock_tag, mock_confirm, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        _run_cli(monkeypatch, ["just-akash", "add-funds", "--dseq", "12345", "--deposit", "1.0"])
+        client.deposit_deployment.assert_not_called()
+        assert "Cancelled" in capsys.readouterr().out
+
+
+# ── auto-topup ───────────────────────────────────────────────────────
+
+
+class TestCliAutoTopup:
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_on(self, MockAPI, mock_tag, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345", "--on"])
+        client.set_auto_top_up.assert_called_once_with("12345", True)
+        assert "enabled" in capsys.readouterr().out
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_off(self, MockAPI, mock_tag, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345", "--off"])
+        client.set_auto_top_up.assert_called_once_with("12345", False)
+        assert "disabled" in capsys.readouterr().out
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_show_unset(self, MockAPI, mock_tag, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        client.get_deployment_settings.return_value = {}
+        _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345"])
+        client.set_auto_top_up.assert_not_called()
+        assert "not configured" in capsys.readouterr().out
+
+    @patch("just_akash.api._get_tag", return_value="")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_show_enabled_with_details(self, MockAPI, mock_tag, monkeypatch, capsys):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        client = MockAPI.return_value
+        client.get_deployment_settings.return_value = {
+            "autoTopUpEnabled": True,
+            "topUpFrequencyMs": 86400000,
+        }
+        _run_cli(monkeypatch, ["just-akash", "auto-topup", "--dseq", "12345"])
+        out = capsys.readouterr().out
+        assert "auto top-up on" in out
+        assert "topUpFrequencyMs" in out
+
+    def test_on_and_off_mutually_exclusive(self, monkeypatch):
+        with pytest.raises(SystemExit) as e:
+            _run_cli(
+                monkeypatch,
+                ["just-akash", "auto-topup", "--dseq", "12345", "--on", "--off"],
+            )
+        assert e.value.code == 2

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -289,7 +289,9 @@ class TestEnrichProviderHostUri:
 
     def test_keeps_existing_nonblank_hosturi(self):
         client = MagicMock()
-        dep = {"leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": "https://keep"}}]}
+        dep = {
+            "leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": "https://keep"}}]
+        }
         out = _enrich_deployment_with_provider(client, dep)
         assert out["leases"][0]["provider"]["hostUri"] == "https://keep"
         client.get_provider.assert_not_called()

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -80,6 +80,24 @@ class TestCliLogs:
         # Must not propagate KeyboardInterrupt.
         _run_cli(monkeypatch, ["just-akash", "logs", "--dseq", "12345"])
 
+    @patch("just_akash.cli._make_lease_shell")
+    @patch("just_akash.api.AkashConsoleAPI")
+    def test_logs_stream_runtimeerror_exits_1_not_traceback(
+        self, MockAPI, mock_make, monkeypatch, capsys
+    ):
+        # The logs handler wraps stream_logs in an inner try that only catches
+        # KeyboardInterrupt; a RuntimeError raised mid-stream (e.g. provider
+        # resolution failing after the transport is built) must fall through to
+        # the outer RuntimeError handler -> friendly message + exit 1, never an
+        # uncaught traceback.
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        transport = mock_make.return_value
+        transport.stream_logs.side_effect = RuntimeError("provider resolution failed mid-stream")
+        with pytest.raises(SystemExit) as e:
+            _run_cli(monkeypatch, ["just-akash", "logs", "--dseq", "12345"])
+        assert e.value.code == 1
+        assert "provider resolution failed mid-stream" in capsys.readouterr().err
+
 
 # ── events ───────────────────────────────────────────────────────────
 

--- a/tests/test_cli_extensions.py
+++ b/tests/test_cli_extensions.py
@@ -278,21 +278,26 @@ class TestCliAutoTopup:
         client.set_auto_top_up.assert_called_once_with("12345", True)
 
 
+def _dep_with_lease(provider):
+    """Build a deployment dict with one lease (id.provider=akash1p)."""
+    lease = {"id": {"provider": "akash1p"}, "provider": provider}
+    return {"leases": [lease]}
+
+
 class TestEnrichProviderHostUri:
     def test_backfills_blank_hosturi_from_registry(self):
         client = MagicMock()
         client.get_provider.return_value = {"hostUri": "https://p.example:8443"}
-        dep = {"leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": ""}}]}
-        out = _enrich_deployment_with_provider(client, dep)
-        assert out["leases"][0]["provider"]["hostUri"] == "https://p.example:8443"
+        out = _enrich_deployment_with_provider(client, _dep_with_lease({"hostUri": ""}))
+        host = out["leases"][0]["provider"]["hostUri"]
+        assert host == "https://p.example:8443"
         client.get_provider.assert_called_once_with("akash1p")
 
     def test_keeps_existing_nonblank_hosturi(self):
         client = MagicMock()
-        dep = {
-            "leases": [{"id": {"provider": "akash1p"}, "provider": {"hostUri": "https://keep"}}]
-        }
-        out = _enrich_deployment_with_provider(client, dep)
+        out = _enrich_deployment_with_provider(
+            client, _dep_with_lease({"hostUri": "https://keep"})
+        )
         assert out["leases"][0]["provider"]["hostUri"] == "https://keep"
         client.get_provider.assert_not_called()
 

--- a/tests/test_lease_shell_exec.py
+++ b/tests/test_lease_shell_exec.py
@@ -86,7 +86,7 @@ class TestJWTFetch:
             result = transport._fetch_jwt(ttl=7200)
 
             assert result == "jwt-token-abc123"
-            mock_api.create_jwt.assert_called_once_with("123456", ttl=7200)
+            mock_api.create_jwt.assert_called_once_with("123456", ttl=7200, scope=None)
 
     def test_fetch_jwt_with_default_ttl(self):
         """Test _fetch_jwt() uses default TTL of 3600."""
@@ -104,7 +104,7 @@ class TestJWTFetch:
 
             transport._fetch_jwt()
 
-            mock_api.create_jwt.assert_called_once_with("789", ttl=3600)
+            mock_api.create_jwt.assert_called_once_with("789", ttl=3600, scope=None)
 
     def test_fetch_jwt_error_propagates(self):
         """Test _fetch_jwt() propagates RuntimeError from create_jwt."""

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -1,0 +1,305 @@
+"""Tests for LeaseShellTransport streaming: logs and kube events.
+
+Covers message formatters, URL builders, and stream_logs/stream_events
+end-to-end against a fake WebSocket (with proxy-envelope unwrapping).
+"""
+
+import base64
+import json
+from unittest.mock import patch
+
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+
+from just_akash.transport.base import TransportConfig
+from just_akash.transport.lease_shell import LeaseShellTransport
+
+DEPLOYMENT_FIXTURE = {
+    "leases": [
+        {
+            "provider": {"hostUri": "https://provider.us-east.akash.pub:8443"},
+            "status": {"services": {"web": {"ready_replicas": 1, "total": 1}}},
+        }
+    ]
+}
+
+
+class FakeWebSocket:
+    """Serves pre-built frames then closes (ConnectionClosedOK)."""
+
+    def __init__(self, frames, close_exc=None):
+        self._frames = iter(frames)
+        self.sent_messages: list = []
+        self._close_exc = close_exc or ConnectionClosedOK(None, None)
+
+    def recv(self, timeout=None):
+        try:
+            return next(self._frames)
+        except StopIteration:
+            raise self._close_exc from None
+
+    def send(self, data):
+        self.sent_messages.append(data)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+    def close(self):
+        pass
+
+
+def _make_transport():
+    config = TransportConfig(dseq="123", api_key="key", deployment=DEPLOYMENT_FIXTURE)
+    return LeaseShellTransport(config)
+
+
+def _proxy_envelope(payload: bytes) -> str:
+    """Wrap raw provider bytes in the proxy JSON envelope (base64 message)."""
+    return json.dumps(
+        {"type": "data", "message": {"data": base64.b64encode(payload).decode("ascii")}}
+    )
+
+
+# ── log message formatter ────────────────────────────────────────────
+
+
+class TestFormatLogMessage:
+    def test_json_with_name_and_message(self):
+        raw = json.dumps({"name": "web", "message": "ready to serve"}).encode()
+        assert LeaseShellTransport._format_log_message(raw) == "[web] ready to serve"
+
+    def test_json_message_without_name(self):
+        raw = json.dumps({"message": "no service"}).encode()
+        assert LeaseShellTransport._format_log_message(raw) == "no service"
+
+    def test_json_service_key_alias(self):
+        raw = json.dumps({"service": "db", "msg": "up"}).encode()
+        assert LeaseShellTransport._format_log_message(raw) == "[db] up"
+
+    def test_raw_text_passthrough(self):
+        assert LeaseShellTransport._format_log_message(b"plain log line\n") == "plain log line"
+
+    def test_brace_prefixed_but_invalid_json_passthrough(self):
+        # Looks like JSON but isn't — must not crash, returns verbatim.
+        assert LeaseShellTransport._format_log_message(b"{not json") == "{not json"
+
+    def test_trailing_newline_stripped(self):
+        raw = json.dumps({"name": "web", "message": "line"}).encode() + b"\n"
+        assert LeaseShellTransport._format_log_message(raw) == "[web] line"
+
+
+# ── event message formatter ──────────────────────────────────────────
+
+
+class TestFormatEventMessage:
+    def test_full_event(self):
+        raw = json.dumps(
+            {
+                "type": "Normal",
+                "reason": "Scheduled",
+                "message": "assigned to node-3",
+                "involvedObject": {"kind": "Pod", "name": "web-1"},
+                "lastTimestamp": "2026-05-22T16:12:01Z",
+            }
+        ).encode()
+        out = LeaseShellTransport._format_event_message(raw)
+        assert "Normal" in out
+        assert "Scheduled" in out
+        assert "Pod/web-1" in out
+        assert "assigned to node-3" in out
+        assert "2026-05-22T16:12:01Z" in out
+
+    def test_object_alias_and_note(self):
+        raw = json.dumps(
+            {
+                "type": "Warning",
+                "reason": "Failed",
+                "note": "img pull",
+                "object": {"kind": "Pod", "name": "p"},
+            }
+        ).encode()
+        out = LeaseShellTransport._format_event_message(raw)
+        assert "Warning" in out and "Failed" in out and "Pod/p" in out and "img pull" in out
+
+    def test_invalid_json_passthrough(self):
+        assert LeaseShellTransport._format_event_message(b"not json") == "not json"
+
+    def test_non_dict_json_passthrough(self):
+        assert LeaseShellTransport._format_event_message(b"[1, 2]") == "[1, 2]"
+
+    def test_partial_event_no_object(self):
+        raw = json.dumps({"type": "Normal", "reason": "Pulled"}).encode()
+        out = LeaseShellTransport._format_event_message(raw)
+        assert out == "Normal  Pulled"
+
+
+# ── URL builders ─────────────────────────────────────────────────────
+
+
+class TestBuildLogsUrl:
+    def test_defaults(self):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        url = t._build_logs_url()
+        assert url == "https://p.com/lease/123/1/1/logs?follow=false&tail=100"
+
+    def test_follow_and_tail(self):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        url = t._build_logs_url(follow=True, tail=50)
+        assert "follow=true" in url and "tail=50" in url
+
+    def test_service_url_encoded(self):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        url = t._build_logs_url(service="my svc")
+        assert "service=my%20svc" in url
+
+    def test_no_service_param_when_absent(self):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        assert "service=" not in t._build_logs_url()
+
+
+class TestBuildEventsUrl:
+    def test_path(self):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        assert t._build_events_url() == "https://p.com/lease/123/1/1/kubeevents"
+
+
+# ── stream_logs end-to-end ───────────────────────────────────────────
+
+
+class TestStreamLogs:
+    def test_prints_raw_byte_frames(self, capsys):
+        t = _make_transport()
+        frames = [b'{"name":"web","message":"hello"}', b"plain line"]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt") as mock_jwt,
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            fake_ws = FakeWebSocket(frames)
+            mock_connect.return_value = fake_ws
+            t.stream_logs(follow=False, tail=10)
+        out = capsys.readouterr().out
+        assert "[web] hello" in out
+        assert "plain line" in out
+        # JWT requested with the logs scope.
+        assert mock_jwt.call_args.kwargs["scope"] == ["logs"]
+        # The provider URL embedded in the proxy connect message targets /logs.
+        connect_msg = json.loads(fake_ws.sent_messages[0])
+        assert "/lease/123/1/1/logs" in connect_msg["url"]
+        assert "tail=10" in connect_msg["url"]
+
+    def test_unwraps_proxy_envelope(self, capsys):
+        t = _make_transport()
+        frames = [_proxy_envelope(b'{"name":"api","message":"served"}')]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = FakeWebSocket(frames)
+            t.stream_logs()
+        assert "[api] served" in capsys.readouterr().out
+
+    def test_follow_passes_through_to_url(self, capsys):
+        t = _make_transport()
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            fake_ws = FakeWebSocket([b"x"])
+            mock_connect.return_value = fake_ws
+            t.stream_logs(follow=True, tail=5)
+        connect_msg = json.loads(fake_ws.sent_messages[0])
+        assert "follow=true" in connect_msg["url"]
+
+
+# ── stream_events end-to-end ─────────────────────────────────────────
+
+
+class TestStreamEvents:
+    def test_prints_events_and_uses_events_scope(self, capsys):
+        t = _make_transport()
+        frames = [
+            json.dumps(
+                {
+                    "type": "Normal",
+                    "reason": "Started",
+                    "involvedObject": {"kind": "Pod", "name": "p"},
+                }
+            ).encode()
+        ]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt") as mock_jwt,
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            fake_ws = FakeWebSocket(frames)
+            mock_connect.return_value = fake_ws
+            t.stream_events()
+        out = capsys.readouterr().out
+        assert "Started" in out and "Pod/p" in out
+        assert mock_jwt.call_args.kwargs["scope"] == ["events"]
+        connect_msg = json.loads(fake_ws.sent_messages[0])
+        assert "/lease/123/1/1/kubeevents" in connect_msg["url"]
+
+
+# ── _stream resilience ───────────────────────────────────────────────
+
+
+class TestStreamResilience:
+    def test_timeout_then_data_then_close(self, capsys):
+        """A TimeoutError mid-stream must not end the stream (follow semantics)."""
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+
+        class TimeoutThenData(FakeWebSocket):
+            def __init__(self):
+                super().__init__([])
+                self._step = 0
+
+            def recv(self, timeout=None):
+                self._step += 1
+                if self._step == 1:
+                    raise TimeoutError()
+                if self._step == 2:
+                    return b"after timeout"
+                raise ConnectionClosedOK(None, None)
+
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = TimeoutThenData()
+            t._stream("https://p.com/lease/123/1/1/logs?", ["logs"], t._format_log_message, 1)
+        assert "after timeout" in capsys.readouterr().out
+
+    def test_connection_closed_error_ends_cleanly(self, capsys):
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        fake_ws = FakeWebSocket([b"one"], close_exc=ConnectionClosedError(rcvd=None, sent=None))
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = fake_ws
+            t._stream("https://p.com/lease/123/1/1/logs?", ["logs"], t._format_log_message, 1)
+        assert "one" in capsys.readouterr().out
+
+    def test_none_frames_skipped(self, capsys):
+        """ping/pong frames decode to None and must be skipped, not printed."""
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        frames = [json.dumps({"type": "ping"}), b"real"]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = FakeWebSocket(frames)
+            t._stream("https://p.com/lease/123/1/1/logs?", ["logs"], t._format_log_message, 1)
+        out = capsys.readouterr().out
+        assert "real" in out
+        assert "ping" not in out

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -6,7 +6,7 @@ end-to-end against a fake WebSocket (with proxy-envelope unwrapping).
 
 import base64
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
@@ -272,6 +272,53 @@ class TestStreamEvents:
         assert mock_jwt.call_args.kwargs["scope"] == ["events"]
         connect_msg = json.loads(fake_ws.sent_messages[0])
         assert "/lease/123/1/1/kubeevents" in connect_msg["url"]
+
+
+# ── provider-scoped JWT carries the iteration's scope ────────────────
+
+
+class TestStreamProviderScopedJwt:
+    def test_logs_provider_scoped_jwt_uses_logs_scope_not_shell(self, capsys):
+        """When the lease exposes only a provider ADDRESS (id.provider) and no
+        embedded hostUri, _resolve_provider sets _provider_address and resolves
+        the hostUri via get_provider. _fetch_jwt must then route through
+        create_jwt_with_provider carrying scope=["logs"] (the streaming scope),
+        NOT the default ["shell"]. This whole branch is unexercised by the other
+        tests, which mock _fetch_jwt out entirely.
+        """
+        deployment = {
+            "leases": [
+                {
+                    "id": {"provider": "akash1prov"},
+                    "status": {"services": {"web": {"ready_replicas": 1, "total": 1}}},
+                }
+            ]
+        }
+        cfg = TransportConfig(dseq="123", api_key="key", deployment=deployment)
+        t = LeaseShellTransport(cfg)
+
+        fake_client = MagicMock()
+        fake_client.get_provider.return_value = {"hostUri": "https://p.example:8443"}
+        fake_client.create_jwt_with_provider.return_value = "jwt-prov"
+
+        with (
+            patch.object(t, "_get_api_client", return_value=fake_client),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = FakeWebSocket([b"line"])
+            t.stream_logs(follow=False, tail=10)
+
+        # Provider-scoped JWT path was taken (address present, no embedded hostUri).
+        assert fake_client.create_jwt_with_provider.called
+        assert not fake_client.create_jwt.called
+        _, kwargs = fake_client.create_jwt_with_provider.call_args
+        assert kwargs["scope"] == ["logs"], (
+            f"provider-scoped JWT must carry the logs scope, got {kwargs.get('scope')!r}"
+        )
+        # And the resolved hostUri (from get_provider) is embedded in the URL.
+        connect_msg = json.loads(mock_connect.return_value.sent_messages[0])
+        assert connect_msg["url"].startswith("https://p.example:8443/lease/123/1/1/logs")
+        assert connect_msg["providerAddress"] == "akash1prov"
 
 
 # ── _stream resilience ───────────────────────────────────────────────

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -89,6 +89,17 @@ class TestFormatLogMessage:
         raw = json.dumps({"name": "web", "message": "line"}).encode() + b"\n"
         assert LeaseShellTransport._format_log_message(raw) == "[web] line"
 
+    def test_json_dict_without_known_keys_is_not_swallowed(self):
+        # A structured JSON log line with none of name/service/message/msg
+        # (e.g. a JSON-logger emitting {"level":"info","ts":...}) is real log
+        # output. The formatter computes name="" and msg="" then renders
+        # str("") == "", so the entire entry is replaced by a blank line —
+        # silent data loss. A faithful copy must surface the original payload.
+        raw = json.dumps({"level": "info", "ts": 1716393600}).encode()
+        out = LeaseShellTransport._format_log_message(raw)
+        assert out != ""
+        assert "info" in out
+
 
 # ── event message formatter ──────────────────────────────────────────
 

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -321,6 +321,37 @@ class TestStreamProviderScopedJwt:
         assert connect_msg["providerAddress"] == "akash1prov"
 
 
+# ── _resolve_provider host-uri fallback ──────────────────────────────
+
+
+class TestResolveProviderHostUriFallback:
+    def test_blank_embedded_hosturi_falls_back_to_provider_registry(self):
+        """An empty embedded ``provider.hostUri`` must NOT be returned as a usable
+        URL; with a valid ``id.provider`` address present, _resolve_provider must
+        fall through to the provider-registry lookup (get_provider) and use that
+        hostUri instead. A blank hostUri short-circuiting here would yield a
+        proxy URL like ``/lease/...`` with no host, silently breaking the stream.
+        """
+        deployment = {
+            "leases": [{"id": {"provider": "akash1x"}, "provider": {"hostUri": ""}}]
+        }
+        cfg = TransportConfig(dseq="123", api_key="key", deployment=deployment)
+        t = LeaseShellTransport(cfg)
+
+        fake_client = MagicMock()
+        fake_client.get_provider.return_value = {"hostUri": "https://resolved.example:8443"}
+
+        with patch.object(t, "_get_api_client", return_value=fake_client):
+            host = t._resolve_provider()
+
+        # The blank embedded hostUri is rejected; the registry value wins.
+        assert host == "https://resolved.example:8443"
+        assert t._provider_host_uri == "https://resolved.example:8443"
+        # The lease's id.provider address was captured and used for the lookup.
+        assert t._provider_address == "akash1x"
+        fake_client.get_provider.assert_called_once_with("akash1x")
+
+
 # ── _stream resilience ───────────────────────────────────────────────
 
 

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -134,6 +134,22 @@ class TestFormatEventMessage:
         out = LeaseShellTransport._format_event_message(raw)
         assert out == "Normal  Pulled"
 
+    def test_numeric_message_zero_is_not_silently_dropped(self):
+        # An event whose `message` is the number 0 (a valid JSON value) must
+        # still appear in the rendered line. The formatter uses
+        # `obj.get("message") or obj.get("note") or ""`, so a falsy-but-present
+        # numeric message (0) is discarded — silent data loss.
+        raw = json.dumps(
+            {
+                "type": "Normal",
+                "reason": "Probe",
+                "involvedObject": {"kind": "Pod", "name": "p"},
+                "message": 0,
+            }
+        ).encode()
+        out = LeaseShellTransport._format_event_message(raw)
+        assert "0" in out
+
 
 # ── URL builders ─────────────────────────────────────────────────────
 
@@ -303,3 +319,23 @@ class TestStreamResilience:
         out = capsys.readouterr().out
         assert "real" in out
         assert "ping" not in out
+
+    def test_blank_log_line_between_two_lines_is_preserved(self, capsys):
+        """A genuinely empty log line (container prints a blank line) must be
+        emitted so the stream is a faithful copy. `_stream` guards with
+        `if line:`, so a frame that formats to "" is silently dropped, and the
+        two surrounding lines collapse together — losing the blank separator.
+        """
+        t = _make_transport()
+        t._provider_host_uri = "https://p.com"
+        # Middle frame is a bare newline -> formats to "" (a real blank line).
+        frames = [b"before", b"\n", b"after"]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt"),
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = FakeWebSocket(frames)
+            t._stream("https://p.com/lease/123/1/1/logs?", ["logs"], t._format_log_message, 1)
+        out = capsys.readouterr().out
+        # Faithful output keeps the blank line between the two log lines.
+        assert out == "before\n\nafter\n"

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -332,9 +332,7 @@ class TestResolveProviderHostUriFallback:
         hostUri instead. A blank hostUri short-circuiting here would yield a
         proxy URL like ``/lease/...`` with no host, silently breaking the stream.
         """
-        deployment = {
-            "leases": [{"id": {"provider": "akash1x"}, "provider": {"hostUri": ""}}]
-        }
+        deployment = {"leases": [{"id": {"provider": "akash1x"}, "provider": {"hostUri": ""}}]}
         cfg = TransportConfig(dseq="123", api_key="key", deployment=deployment)
         t = LeaseShellTransport(cfg)
 

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -1,0 +1,122 @@
+"""Tests for deploy.update() (in-place PUT) and the shared _prepare_sdl_content."""
+
+from unittest.mock import patch
+
+import pytest
+
+from just_akash.deploy import _prepare_sdl_content, update
+
+SDL_YAML = """
+version: "2.0"
+services:
+  web:
+    image: python:3.13-slim
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+"""
+
+SDL_WITH_SSH_PLACEHOLDER = SDL_YAML.replace(
+    "image: python:3.13-slim",
+    "image: python:3.13-slim\n    env:\n      - SSH_PUBKEY_B64=PLACEHOLDER_SSH_PUBKEY_B64",
+)
+
+
+# ── _prepare_sdl_content ─────────────────────────────────────────────
+
+
+class TestPrepareSdlContent:
+    def test_reads_and_returns(self, tmp_path):
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        out = _prepare_sdl_content(str(f))
+        assert "python:3.13-slim" in out
+
+    def test_missing_file_raises(self):
+        with pytest.raises(RuntimeError, match="SDL file not found"):
+            _prepare_sdl_content("/nope/missing.yaml")
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        f = tmp_path / "bad.yaml"
+        f.write_text("::: not yaml :::\n- [")
+        with pytest.raises(RuntimeError):
+            _prepare_sdl_content(str(f))
+
+    def test_image_override(self, tmp_path):
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        out = _prepare_sdl_content(str(f), image="myrepo/app:v2")
+        assert "image: myrepo/app:v2" in out
+        assert "python:3.13-slim" not in out
+
+    def test_env_injection(self, tmp_path):
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        out = _prepare_sdl_content(str(f), env_vars=["FOO=bar"])
+        assert "FOO=bar" in out
+
+    def test_ssh_placeholder_without_key_raises(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SSH_PUBKEY", raising=False)
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_WITH_SSH_PLACEHOLDER)
+        with pytest.raises(RuntimeError, match="SSH_PUBKEY"):
+            _prepare_sdl_content(str(f))
+
+    def test_ssh_placeholder_with_key_injects_base64(self, tmp_path, monkeypatch):
+        import base64
+
+        monkeypatch.setenv("SSH_PUBKEY", "ssh-ed25519 AAAAKEY")
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_WITH_SSH_PLACEHOLDER)
+        out = _prepare_sdl_content(str(f))
+        assert "PLACEHOLDER_SSH_PUBKEY_B64" not in out
+        assert base64.b64encode(b"ssh-ed25519 AAAAKEY").decode() in out
+
+
+# ── update() ─────────────────────────────────────────────────────────
+
+
+class TestUpdate:
+    def test_requires_api_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AKASH_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="AKASH_API_KEY"):
+            update(dseq="123", sdl_path=str(tmp_path / "s.yaml"))
+
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_update_calls_put_with_prepared_sdl(self, MockAPI, tmp_path, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        client = MockAPI.return_value
+        client.update_deployment.return_value = {"dseq": "123", "state": "active"}
+
+        result = update(dseq="123", sdl_path=str(f), image="repo/app:v3")
+
+        assert result["dseq"] == "123"
+        client.update_deployment.assert_called_once()
+        called_dseq, called_sdl = client.update_deployment.call_args[0]
+        assert called_dseq == "123"
+        assert "image: repo/app:v3" in called_sdl
+
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_update_wraps_api_error(self, MockAPI, tmp_path, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        client = MockAPI.return_value
+        client.update_deployment.side_effect = RuntimeError("API Error (409): conflict")
+
+        with pytest.raises(RuntimeError, match="Failed to update deployment 123"):
+            update(dseq="123", sdl_path=str(f))
+
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_update_invalid_sdl_rejected_before_api(self, MockAPI, tmp_path, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        f = tmp_path / "bad.yaml"
+        f.write_text("not: [valid")
+        client = MockAPI.return_value
+        with pytest.raises(RuntimeError):
+            update(dseq="123", sdl_path=str(f))
+        client.update_deployment.assert_not_called()

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -57,6 +57,31 @@ class TestPrepareSdlContent:
         out = _prepare_sdl_content(str(f), env_vars=["FOO=bar"])
         assert "FOO=bar" in out
 
+    def test_image_override_does_not_target_comment_line(self, tmp_path):
+        # The override regex is `image:\s+[^\n]+` with count=1, so it replaces
+        # the FIRST occurrence of "image: " anywhere in the file. A YAML comment
+        # that mentions "image:" (e.g. "# bump the image: see notes") sits above
+        # the real `image:` key, so the comment gets rewritten and the actual
+        # container image is left untouched — the override silently no-ops.
+        sdl = """version: "2.0"
+services:
+  web:
+    # remember to bump the image: see release notes
+    image: python:3.13-slim
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+"""
+        f = tmp_path / "s.yaml"
+        f.write_text(sdl)
+        out = _prepare_sdl_content(str(f), image="myrepo/app:v9")
+        # The real container image must be overridden...
+        assert "image: python:3.13-slim" not in out
+        # ...and the comment line must NOT have been hijacked as the target.
+        assert "# remember to bump the image: see release notes" in out
+
     def test_ssh_placeholder_without_key_raises(self, tmp_path, monkeypatch):
         monkeypatch.delenv("SSH_PUBKEY", raising=False)
         f = tmp_path / "s.yaml"

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from just_akash.deploy import _prepare_sdl_content, update
+from just_akash.deploy import _prepare_sdl_content, deploy, update
 
 SDL_YAML = """
 version: "2.0"
@@ -145,3 +145,19 @@ class TestUpdate:
         with pytest.raises(RuntimeError):
             update(dseq="123", sdl_path=str(f))
         client.update_deployment.assert_not_called()
+
+
+class TestDeployDepositGuard:
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_nan_deposit_rejected_before_api(self, MockAPI, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(RuntimeError, match="Invalid deposit"):
+            deploy(sdl_path="ignored.yaml", deposit=float("nan"))
+        MockAPI.return_value.create_deployment.assert_not_called()
+
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_non_positive_deposit_rejected(self, MockAPI, monkeypatch):
+        monkeypatch.setenv("AKASH_API_KEY", "k")
+        with pytest.raises(RuntimeError, match="Invalid deposit"):
+            deploy(sdl_path="ignored.yaml", deposit=0)
+        MockAPI.return_value.create_deployment.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "just-akash"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "pexpect" },


### PR DESCRIPTION
## Summary

Closes the gaps between **deploy** and **teardown** by wiring up the five Console API endpoints just-akash wasn't using, then hardening the new code and adding security tooling. All request/response shapes were verified against the `akash-network/console` source.

### New commands (CLI + Justfile recipes)
| Command | Endpoint |
|---|---|
| `update` — revise a running deployment in place (keeps DSEQ + lease, no re-bid) | `PUT /v1/deployments/{dseq}` |
| `logs` — stream container logs (`--follow`/`--tail`/`--service`) | `WSS …/lease/.../logs` |
| `events` — stream Kubernetes events (debug startup) | `WSS …/lease/.../kubeevents` |
| `add-funds` — top up escrow in USD (min 0.5) | `POST /v1/deposit-deployment` |
| `auto-topup` — show/toggle auto escrow top-up | `GET/POST/PATCH /v2/deployment-settings` |

API client gains `update_deployment`, `deposit_deployment`, `get/create/update_deployment_settings`, `set_auto_top_up` (upsert), plus a `scope` param on `create_jwt`/`create_jwt_with_provider` so one JWT path serves shell/logs/events. SDL prep (read → validate → image/SSH/env) is extracted to `_prepare_sdl_content`, shared by `deploy()` and `update()`.

## Adversarial hardening (`/nf:harden`, 6 iterations → converged)
Fixed **9 real edge-case bugs** in the new code (one per `harden iteration` commit):
- loose `404` detection swallowing 400/500 errors
- dropped/`0` log + event messages; blank log lines collapsed
- `--image` override hijacking a `# comment` mentioning `image:`
- non-bool `auto-topup` display reading `"false"` as on
- `{"data": null}` wrapper leak → `set_auto_top_up` PATCHing a nonexistent record (first-time topup would 404)
- non-finite `add-funds` deposit (`nan`/`inf`) bypassing the minimum guard

## Security tooling
- **Ruff bandit rules (`S`)** in the lint job (triaged; `S602` stays active).
- **Semgrep SAST** — `just semgrep` + a `Security` CI workflow (clean).
- **pip-audit** dependency CVE check — `just audit` + CI (weekly cron). Clean.
- Fix it surfaced: the SSH-fallback `inject` now `shlex.quote`s `--remote-path`.

See `SECURITY.md` for the rationale on the two excluded (CLI-inherent) Semgrep rules.

## Testing
- **752 tests passing** (rebased onto current `main`, including its stale-bid tests).
- ruff + `S`, format, pyright all clean; new `.github/workflows/security.yml`.

## Notes
- Deposits are **USD** per the Console API (`"Amount to deposit in dollars"`) — corrected the stale `deploy --deposit` "AKT" help/log.
- Streaming and escrow commands need a live deployment + real funds, so they're covered by unit tests (request/response wiring); not exercised against the live API in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added full deployment lifecycle CLI commands: `update`, `logs`, `events`, `add-funds`, and `auto-topup`, plus enhanced SDL/image/env handling.
  * Deployment creation now supports a configurable deposit amount.
  * Log/event streaming now formats output more cleanly and supports provider-scoped JWTs.

* **Security**
  * Added CI static analysis (Semgrep) and dependency vulnerability auditing (pip-audit).
  * Hardened SSH remote-path handling and improved security scanning configuration.

* **Documentation**
  * Updated README, changelog, and SECURITY policy with new commands and security tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->