### PR TITLE
harden: transport robustness + deploy-loop safety (deep-eval follow-ups)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 272
+        "line_number": 295
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -303,7 +303,7 @@
         "filename": "tests/test_transport.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 159
       }
     ],
     "tests/test_transport_cli_integration.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T13:42:46Z"
+  "generated_at": "2026-06-22T14:45:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "just_akash/deploy.py",
         "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
         "is_verified": false,
-        "line_number": 295
+        "line_number": 296
       }
     ],
     "just_akash/test_secrets_e2e.py": [
@@ -303,7 +303,7 @@
         "filename": "tests/test_transport.py",
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 184
       }
     ],
     "tests/test_transport_cli_integration.py": [
@@ -339,5 +339,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-22T14:45:05Z"
+  "generated_at": "2026-06-22T14:58:59Z"
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,14 @@ This tool deploys compute instances on Akash Network via the Console API. The ma
 - **`AKASH_API_KEY`** — your Console API key. Read from environment, never hardcoded.
 - **`SSH_PUBKEY`** — injected into containers at deploy time. Not stored in the repo.
 - **Provider allowlist** — controls which providers can host your workloads. Keep it restricted to providers you trust.
+- **Secret injection (`inject`)** — secrets are written to the container over the
+  Console provider-proxy WebSocket (TLS-encrypted in transit). The lease-shell
+  transport sends them as a base64 argument to `base64 -d`, so the encoded
+  secret is briefly visible in the **provider host's** process table
+  (`ps` / `/proc/<pid>/cmdline`) while the command runs. This only exposes the
+  secret to an operator/co-tenant already on the provider host you've chosen to
+  trust with your workload. Use only trusted (ideally allowlisted/audited)
+  providers for sensitive secrets.
 
 ## Secret Scanning
 

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -269,7 +269,8 @@ def _prepare_sdl_content(
         # Reject malformed entries before they become a broken SDL env line
         # (mirrors the `inject` command's validation).
         for var in env_vars:
-            if "=" not in var:
+            key, sep, _ = var.partition("=")
+            if not sep or not key:
                 raise RuntimeError(f"Invalid --env {var!r}: expected KEY=VALUE")
         sdl_content = _inject_env_into_sdl(sdl_content, env_vars)
         _log(logging.INFO, f"Injected {len(env_vars)} env var(s) into SDL (provider-visible)")

--- a/just_akash/deploy.py
+++ b/just_akash/deploy.py
@@ -194,6 +194,24 @@ def _resolve_tier(arg_value: list[str] | None, env_name: str) -> list[str]:
     return [a.strip() for a in raw.split(",") if a.strip()]
 
 
+def _resolve_sdl_path(sdl_path: str, gpu: bool) -> str:
+    """When ``gpu`` is set, prefer a ``<stem>-gpu<suffix>`` sibling SDL.
+
+    Returns the GPU variant path if it exists next to ``sdl_path``, otherwise
+    the original path (with a warning). This makes the ``--gpu`` flag honest:
+    "use the GPU variant SDL if available".
+    """
+    if not gpu:
+        return sdl_path
+    p = Path(sdl_path)
+    variant = p.with_name(f"{p.stem}-gpu{p.suffix}")
+    if variant.exists():
+        _log(logging.INFO, f"GPU mode: using GPU SDL variant {variant}")
+        return str(variant)
+    _log(logging.WARNING, f"--gpu set but no GPU variant found at {variant}; using {sdl_path}")
+    return sdl_path
+
+
 def _prepare_sdl_content(
     sdl_path: str,
     image: str | None = None,
@@ -248,6 +266,11 @@ def _prepare_sdl_content(
         _log(logging.INFO, "Injected SSH public key (base64) into SDL")
 
     if env_vars:
+        # Reject malformed entries before they become a broken SDL env line
+        # (mirrors the `inject` command's validation).
+        for var in env_vars:
+            if "=" not in var:
+                raise RuntimeError(f"Invalid --env {var!r}: expected KEY=VALUE")
         sdl_content = _inject_env_into_sdl(sdl_content, env_vars)
         _log(logging.INFO, f"Injected {len(env_vars)} env var(s) into SDL (provider-visible)")
 
@@ -295,7 +318,8 @@ def deploy(
     if not has_allowlist:
         _log(logging.INFO, "ALLOWED_PROVIDERS: (any — no allowlist set)")
 
-    # Step 1: Read + validate + transform SDL
+    # Step 1: Read + validate + transform SDL (resolve GPU variant first)
+    sdl_path = _resolve_sdl_path(sdl_path, gpu)
     _log(logging.INFO, "STEP 1: Preparing SDL")
     sdl_content = _prepare_sdl_content(sdl_path, image=image, env_vars=env_vars)
 
@@ -813,17 +837,30 @@ def deploy(
             f"All bids on order {dseq} are stale — re-creating the order for "
             "fresh bids (1 re-deploy round)...",
         )
-        try:
-            client.close_deployment(str(dseq))
-            _log(logging.INFO, f"  Stale order {dseq} closed")
-        except Exception as close_err:
-            # Proceed so the deploy can still succeed, but surface the leak
-            # loudly and actionably — the old escrow stays locked until closed.
-            _log(
-                logging.WARNING,
-                f"  WARNING: could not close stale order {dseq} ({close_err}). "
-                f"Its escrow stays locked until you close it: "
-                f"just-akash destroy --dseq {dseq}",
+        # Close the stale order BEFORE creating a new one — never leave two
+        # funded orders on-chain. Transient close failures (often the same
+        # Console flap that triggered the re-deploy) are retried; if the close
+        # persistently fails we abort rather than double-fund escrow.
+        closed = False
+        for close_attempt in range(1, 4):
+            try:
+                client.close_deployment(str(dseq))
+                _log(logging.INFO, f"  Stale order {dseq} closed")
+                closed = True
+                break
+            except Exception as close_err:
+                _log(
+                    logging.WARNING,
+                    f"  Close of stale order {dseq} failed "
+                    f"(attempt {close_attempt}/3): {close_err}",
+                )
+                if close_attempt < 3:
+                    time.sleep(2)
+        if not closed:
+            raise RuntimeError(
+                f"could not close stale order {dseq} after 3 attempts — not "
+                "re-deploying, to avoid double escrow. Close it manually: "
+                f"just-akash destroy --dseq {dseq}"
             )
         try:
             redeploy_response = client.create_deployment(sdl_content, deposit=deposit)

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -796,6 +796,13 @@ class LeaseShellTransport(Transport):
                 return
             attempts += 1
 
+        # Every attempt reconnected on auth-expiry and we ran out — fail loudly
+        # rather than letting `logs --follow` stop silently (mirrors _exec_loop).
+        raise RuntimeError(
+            f"Failed to re-authenticate stream after {MAX_RECONNECT_ATTEMPTS} attempts. "
+            "Check that AKASH_API_KEY is valid."
+        )
+
     def stream_logs(
         self, follow: bool = False, tail: int = 100, service: str | None = None
     ) -> None:

--- a/just_akash/transport/lease_shell.py
+++ b/just_akash/transport/lease_shell.py
@@ -283,6 +283,10 @@ class LeaseShellTransport(Transport):
         if isinstance(raw, str):
             try:
                 msg = json.loads(raw)
+                # A valid-JSON text frame need not be an object (could be an
+                # array / null / scalar); only objects carry the proxy envelope.
+                if not isinstance(msg, dict):
+                    return None
                 msg_type = msg.get("type", "")
                 if msg_type in ("ping", "pong"):
                     return None
@@ -301,7 +305,8 @@ class LeaseShellTransport(Transport):
                     return bytes(message)
                 if isinstance(msg.get("data"), str):
                     return base64.b64decode(msg["data"])
-            except (json.JSONDecodeError, TypeError):
+            # ValueError covers binascii.Error from malformed base64 payloads.
+            except (json.JSONDecodeError, TypeError, ValueError):
                 pass
         return None
 
@@ -731,39 +736,65 @@ class LeaseShellTransport(Transport):
         """Open a provider-proxy WebSocket and print each frame via ``formatter``.
 
         Runs until the server closes the stream (non-follow / snapshot) or the
-        user interrupts (Ctrl-C). Read-only: no stdin is sent. Callers must have
-        already called ``_resolve_provider`` so the proxy URL embeds the host.
+        user interrupts (Ctrl-C). For long-lived follow streams the lease JWT can
+        expire mid-stream; on an auth-expiry close we refetch the token and
+        reconnect (up to MAX_RECONNECT_ATTEMPTS) so the stream resumes instead of
+        ending silently. Any other close ends the stream. Read-only: no stdin is
+        sent. Callers must have already called ``_resolve_provider`` so the proxy
+        URL embeds the host.
         """
-        jwt = self._fetch_jwt(scope=scope)
-        proxy_url = self._get_proxy_ws_url()
-        connect_msg = self._build_proxy_connect_msg(provider_url, jwt)
-        ssl_ctx = ssl.create_default_context()
+        attempts = 0
+        while attempts < MAX_RECONNECT_ATTEMPTS:
+            jwt = self._fetch_jwt(scope=scope)
+            proxy_url = self._get_proxy_ws_url()
+            connect_msg = self._build_proxy_connect_msg(provider_url, jwt)
+            ssl_ctx = ssl.create_default_context()
+            reconnect = False
 
-        with connect(
-            proxy_url,
-            ssl=ssl_ctx,
-            compression=None,
-            open_timeout=30,
-            ping_interval=30,
-            ping_timeout=20,
-        ) as ws:
-            ws.send(connect_msg)
-            while True:
-                try:
-                    frame = self._recv_proxy_message(ws, timeout=recv_timeout)
-                except (ConnectionClosedOK, ConnectionClosedError):
-                    return
-                except TimeoutError:
-                    continue
-                if frame is None:
-                    continue
-                # Every received data frame maps to one output line. Do NOT skip
-                # empty lines — a blank line is real log output and dropping it
-                # would make the stream an unfaithful copy. (ping/pong control
-                # frames already decode to None above and never reach here.)
-                line = formatter(frame)
-                sys.stdout.write(line + "\n")
-                sys.stdout.flush()
+            try:
+                with connect(
+                    proxy_url,
+                    ssl=ssl_ctx,
+                    compression=None,
+                    open_timeout=30,
+                    ping_interval=30,
+                    ping_timeout=20,
+                ) as ws:
+                    ws.send(connect_msg)
+                    while True:
+                        try:
+                            frame = self._recv_proxy_message(ws, timeout=recv_timeout)
+                        except ConnectionClosedOK:
+                            return
+                        except ConnectionClosedError as exc:
+                            # Auth-expiry on a long follow → refetch + reconnect;
+                            # any other close means the stream simply ended.
+                            if _is_auth_expiry(exc):
+                                reconnect = True
+                                break
+                            return
+                        except TimeoutError:
+                            continue
+                        if frame is None:
+                            continue
+                        # Every received data frame maps to one output line. Do
+                        # NOT skip empty lines — a blank line is real log output
+                        # and dropping it would make the stream an unfaithful
+                        # copy. (ping/pong frames already decode to None above.)
+                        line = formatter(frame)
+                        sys.stdout.write(line + "\n")
+                        sys.stdout.flush()
+            except RuntimeError as exc:
+                # A proxy "error" frame about an expired token is recoverable;
+                # any other proxy error propagates to the caller.
+                if _is_auth_expiry_message(str(exc)):
+                    reconnect = True
+                else:
+                    raise
+
+            if not reconnect:
+                return
+            attempts += 1
 
     def stream_logs(
         self, follow: bool = False, tail: int = 100, service: str | None = None

--- a/just_akash/transport/ssh.py
+++ b/just_akash/transport/ssh.py
@@ -1,6 +1,7 @@
 """SSH transport — exact v1.4 behavior wrapped in Transport interface."""
 
 import os
+import shlex
 import subprocess
 from typing import Any
 
@@ -47,21 +48,24 @@ class SSHTransport(Transport):
         assert self._ssh_info is not None, "Call prepare() first"  # noqa: S101 type-narrowing
         assert self._key_path is not None, "Call prepare() first"  # noqa: S101 type-narrowing
         ssh_cmd = _build_ssh_cmd(self._ssh_info, self._key_path)
+        # Quote the path before it reaches the remote shell, matching the
+        # lease-shell transport and the CLI's SSH inject path.
+        quoted_path = shlex.quote(remote_path)
         # mkdir -p
         subprocess.run(
-            ssh_cmd + [f"mkdir -p $(dirname {remote_path})"],
+            ssh_cmd + [f"mkdir -p $(dirname {quoted_path})"],
             capture_output=True,
             text=True,
             check=True,
         )
         # write content
         result = subprocess.run(
-            ssh_cmd + [f"cat > {remote_path}"], input=content, capture_output=True, text=True
+            ssh_cmd + [f"cat > {quoted_path}"], input=content, capture_output=True, text=True
         )
         if result.returncode != 0:
             raise RuntimeError(f"Failed to write secrets: {result.stderr.strip()}")
         # chmod 600
-        subprocess.run(ssh_cmd + [f"chmod 600 {remote_path}"], capture_output=True, text=True)
+        subprocess.run(ssh_cmd + [f"chmod 600 {quoted_path}"], capture_output=True, text=True)
 
     def connect(self) -> None:
         """Interactive SSH shell (replaces process via os.execvp — never returns)."""

--- a/just_akash/transport/ssh.py
+++ b/just_akash/transport/ssh.py
@@ -51,9 +51,10 @@ class SSHTransport(Transport):
         # Quote the path before it reaches the remote shell, matching the
         # lease-shell transport and the CLI's SSH inject path.
         quoted_path = shlex.quote(remote_path)
-        # mkdir -p
+        # mkdir -p — quote the command substitution too, so a dirname result
+        # containing spaces stays a single argument to mkdir.
         subprocess.run(
-            ssh_cmd + [f"mkdir -p $(dirname {quoted_path})"],
+            ssh_cmd + [f'mkdir -p "$(dirname {quoted_path})"'],
             capture_output=True,
             text=True,
             check=True,
@@ -64,8 +65,15 @@ class SSHTransport(Transport):
         )
         if result.returncode != 0:
             raise RuntimeError(f"Failed to write secrets: {result.stderr.strip()}")
-        # chmod 600
-        subprocess.run(ssh_cmd + [f"chmod 600 {quoted_path}"], capture_output=True, text=True)
+        # chmod 600 — fail closed: never report success if the secret file is
+        # left with weaker-than-intended permissions.
+        chmod_result = subprocess.run(
+            ssh_cmd + [f"chmod 600 {quoted_path}"], capture_output=True, text=True
+        )
+        if chmod_result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to set secret-file permissions (chmod 600): {chmod_result.stderr.strip()}"
+            )
 
     def connect(self) -> None:
         """Interactive SSH shell (replaces process via os.execvp — never returns)."""

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -9,9 +9,16 @@ import json
 from unittest.mock import MagicMock, patch
 
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.frames import Close
 
 from just_akash.transport.base import TransportConfig
 from just_akash.transport.lease_shell import LeaseShellTransport
+
+
+def _auth_expiry_close() -> ConnectionClosedError:
+    """A close that _is_auth_expiry recognizes (provider auth code 4001)."""
+    return ConnectionClosedError(rcvd=Close(code=4001, reason="token expired"), sent=None)
+
 
 DEPLOYMENT_FIXTURE = {
     "leases": [
@@ -426,3 +433,55 @@ class TestStreamResilience:
         out = capsys.readouterr().out
         # Faithful output keeps the blank line between the two log lines.
         assert out == "before\n\nafter\n"
+
+
+# ── recv-loop robustness (uncaught-crash regression guard) ────────────
+
+
+class TestRecvProxyMessageRobustness:
+    def test_non_object_json_frames_return_none(self):
+        t = _make_transport()
+        for frame in ["[1, 2, 3]", "null", "42", '"a string"', "true"]:
+            ws = FakeWebSocket([frame])
+            # Must not raise AttributeError — non-object JSON has no envelope.
+            assert t._recv_proxy_message(ws, timeout=1) is None
+
+    def test_malformed_base64_payload_returns_none(self):
+        t = _make_transport()
+        # "abcde" is not valid base64 (length 5 → padding error / binascii.Error).
+        ws = FakeWebSocket([json.dumps({"type": "data", "message": "abcde"})])
+        assert t._recv_proxy_message(ws, timeout=1) is None
+
+
+# ── follow-stream auth-expiry reconnect ───────────────────────────────
+
+
+class TestStreamReconnect:
+    def test_logs_reconnects_on_auth_expiry(self, capsys):
+        t = _make_transport()
+        # First connection serves a line then closes with an auth-expiry code;
+        # the stream should refetch the JWT and reconnect rather than end.
+        ws1 = FakeWebSocket([b"line-before-expiry"], close_exc=_auth_expiry_close())
+        ws2 = FakeWebSocket([b"line-after-reconnect"])  # ends with a clean close
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt") as mock_jwt,
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.side_effect = [ws1, ws2]
+            t.stream_logs(follow=True)
+        out = capsys.readouterr().out
+        assert "line-before-expiry" in out
+        assert "line-after-reconnect" in out
+        assert mock_jwt.call_count == 2  # reconnected with a fresh token
+
+    def test_non_auth_close_ends_stream_without_reconnect(self, capsys):
+        t = _make_transport()
+        ws = FakeWebSocket([b"only-line"], close_exc=ConnectionClosedError(rcvd=None, sent=None))
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt") as mock_jwt,
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.return_value = ws
+            t.stream_logs(follow=True)
+        assert "only-line" in capsys.readouterr().out
+        assert mock_jwt.call_count == 1  # no reconnect on a non-auth close

--- a/tests/test_lease_stream.py
+++ b/tests/test_lease_stream.py
@@ -8,6 +8,7 @@ import base64
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.frames import Close
 
@@ -485,3 +486,22 @@ class TestStreamReconnect:
             t.stream_logs(follow=True)
         assert "only-line" in capsys.readouterr().out
         assert mock_jwt.call_count == 1  # no reconnect on a non-auth close
+
+    def test_raises_when_auth_expiry_exhausts_reconnects(self, capsys):
+        # Every connection closes on auth-expiry; after MAX_RECONNECT_ATTEMPTS
+        # the stream must fail loudly rather than return silently.
+        from just_akash.transport.lease_shell import MAX_RECONNECT_ATTEMPTS
+
+        t = _make_transport()
+        wss = [
+            FakeWebSocket([f"line-{i}".encode()], close_exc=_auth_expiry_close())
+            for i in range(MAX_RECONNECT_ATTEMPTS)
+        ]
+        with (
+            patch.object(t, "_fetch_jwt", return_value="jwt") as mock_jwt,
+            patch("just_akash.transport.lease_shell.connect") as mock_connect,
+        ):
+            mock_connect.side_effect = wss
+            with pytest.raises(RuntimeError, match="Failed to re-authenticate stream"):
+                t.stream_logs(follow=True)
+        assert mock_jwt.call_count == MAX_RECONNECT_ATTEMPTS

--- a/tests/test_stale_bid_selection.py
+++ b/tests/test_stale_bid_selection.py
@@ -369,12 +369,9 @@ class TestLeaseStaleRetry:
 
     @patch("just_akash.deploy.time")
     @patch("just_akash.deploy.AkashConsoleAPI")
-    def test_redeploy_proceeds_when_close_of_stale_order_fails(
-        self, MockAPI, mock_time, tmp_path, monkeypatch, capsys
-    ):
-        """If closing the stale order fails, re-deploy still proceeds (so the
-        deploy can succeed) but warns loudly with an actionable remediation —
-        the old escrow stays locked until manually closed."""
+    def test_redeploy_retries_close_then_proceeds(self, MockAPI, mock_time, tmp_path, monkeypatch):
+        """A transient close failure is retried; once the close succeeds the
+        re-deploy proceeds normally and leases the fresh order."""
         client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
         client.create_deployment.side_effect = [
             {"dseq": "111", "manifest": "m1"},
@@ -382,16 +379,39 @@ class TestLeaseStaleRetry:
         ]
         client.get_bids.return_value = [_make_bid("akash1a", 10)]
         client.create_lease.side_effect = [self.STALE_ERR, {"lease": "ok"}]
-        client.close_deployment.side_effect = RuntimeError("close exploded")
+        # First close attempt flaps, second succeeds.
+        client.close_deployment.side_effect = [RuntimeError("transient flap"), None]
 
         result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
 
         assert result["dseq"] == "222"
-        # Only the stale order's close was attempted (and it failed); the new
-        # order succeeded so no cleanup-close happened.
-        client.close_deployment.assert_called_once_with("111")
-        out = capsys.readouterr().out
-        assert "just-akash destroy --dseq 111" in out
+        assert client.create_deployment.call_count == 2  # re-deploy happened
+        assert client.close_deployment.call_count == 2  # 1 failed + 1 success
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploy_aborts_when_close_persistently_fails(
+        self, MockAPI, mock_time, tmp_path, monkeypatch
+    ):
+        """If the stale order can't be closed after retries, abort rather than
+        double-fund: do NOT create a second order, and surface the orphaned
+        dseq with an actionable remediation."""
+        client, sdl = _setup(MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1a")
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+        client.get_bids.return_value = [_make_bid("akash1a", 10)]
+        client.create_lease.side_effect = self.STALE_ERR
+        client.close_deployment.side_effect = RuntimeError("close exploded")
+
+        with pytest.raises(RuntimeError, match="just-akash destroy --dseq 111"):
+            deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        # Aborted before re-deploy: only the ORIGINAL order was ever created,
+        # so no second (double-funded) order exists.
+        assert client.create_deployment.call_count == 1
+        assert client.close_deployment.call_count == 3  # 3 retries, all failed
 
 
 class TestLeaseTransientJWTRetry:
@@ -432,3 +452,38 @@ class TestLeaseTransientJWTRetry:
         # 3 attempts, all on the same (only) provider, then cleanup.
         assert client.create_lease.call_count == 3
         client.close_deployment.assert_called_once_with("12345")
+
+    @patch("just_akash.deploy.time")
+    @patch("just_akash.deploy.AkashConsoleAPI")
+    def test_redeploy_selects_backup_bid_on_recreated_order(
+        self, MockAPI, mock_time, tmp_path, monkeypatch
+    ):
+        """On the re-created order, when only a BACKUP bid is available, the
+        fast-poll's courtesy-window branch selects it (covers _poll_fresh_bid's
+        backup path). Courtesy=0 accepts the backup immediately."""
+        monkeypatch.setenv("JUST_AKASH_REDEPLOY_BACKUP_COURTESY_S", "0")
+        client, sdl = _setup(
+            MockAPI, mock_time, tmp_path, monkeypatch, providers="akash1pref", backup="akash1back"
+        )
+        client.create_deployment.side_effect = [
+            {"dseq": "111", "manifest": "m1"},
+            {"dseq": "222", "manifest": "m2"},
+        ]
+
+        def _bids(d):
+            # Original order: a preferred bid (drives selection). Re-created
+            # order: only a backup bid.
+            return [_make_bid("akash1pref", 10)] if d == "111" else [_make_bid("akash1back", 50)]
+
+        client.get_bids.side_effect = _bids
+        stale_err = RuntimeError(
+            "API Error (400): Failed to create lease: Cannot create lease: "
+            "The selected bid is no longer open. Please refresh and select an available bid."
+        )
+        client.create_lease.side_effect = [stale_err, {"lease": "ok"}]
+
+        result = deploy(sdl_path=sdl, bid_wait=5, bid_wait_retry=5)
+
+        assert result["dseq"] == "222"
+        assert result["provider"] == "akash1back"  # backup tier selected post-redeploy
+        client.close_deployment.assert_called_once_with("111")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -141,6 +141,31 @@ class TestSSHTransport:
         for cmd in sent_cmds:
             assert quoted in cmd
             assert dangerous not in cmd.replace(quoted, "")
+        # The mkdir command must also quote the $(dirname ...) substitution, so a
+        # directory path containing spaces stays a single argument to mkdir.
+        mkdir_cmd = sent_cmds[0]
+        assert f'"$(dirname {quoted})"' in mkdir_cmd
+
+    def test_inject_fails_closed_when_chmod_fails(self):
+        """If `chmod 600` fails, inject() must raise — never report success with
+        secret material left at weaker-than-intended permissions."""
+        config = TransportConfig(dseq="123", api_key="key")
+        t = SSHTransport(config)
+        t._ssh_info = {"host": "h", "port": 22}
+        t._key_path = "/key"
+
+        ok = MagicMock(returncode=0, stderr="")
+        chmod_fail = MagicMock(returncode=1, stderr="chmod: Operation not permitted")
+        # mkdir, cat, chmod — in order.
+        with (
+            patch("just_akash.transport.ssh._build_ssh_cmd", return_value=["ssh"]),
+            patch(
+                "just_akash.transport.ssh.subprocess.run",
+                side_effect=[ok, ok, chmod_fail],
+            ),
+            pytest.raises(RuntimeError, match="chmod 600"),
+        ):
+            t.inject("/tmp/secret", "content")
 
 
 # --- LeaseShellTransport (Phase 7+) ---

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -114,6 +114,34 @@ class TestSSHTransport:
             rc = t.exec("exit 42")
         assert rc == 42
 
+    def test_inject_shlex_quotes_remote_path(self):
+        """A remote path containing shell metacharacters must be shlex-quoted in
+        every command sent over SSH (mkdir/cat/chmod) — never interpolated raw."""
+        import shlex
+
+        config = TransportConfig(dseq="123", api_key="key")
+        t = SSHTransport(config)
+        t._ssh_info = {"host": "h", "port": 22}
+        t._key_path = "/key"
+        dangerous = "/tmp/x; rm -rf ~"
+        quoted = shlex.quote(dangerous)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with (
+            patch("just_akash.transport.ssh._build_ssh_cmd", return_value=["ssh"]),
+            patch("just_akash.transport.ssh.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            t.inject(dangerous, "secret-content")
+
+        # Every invocation's final argument is the remote command string; the
+        # raw path must never appear unquoted in any of them.
+        sent_cmds = [call.args[0][-1] for call in mock_run.call_args_list]
+        assert sent_cmds, "expected at least one SSH command"
+        for cmd in sent_cmds:
+            assert quoted in cmd
+            assert dangerous not in cmd.replace(quoted, "")
+
 
 # --- LeaseShellTransport (Phase 7+) ---
 

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -57,6 +57,14 @@ class TestPrepareSdlContent:
         out = _prepare_sdl_content(str(f), env_vars=["FOO=bar"])
         assert "FOO=bar" in out
 
+    @pytest.mark.parametrize("bad", ["NOTAPAIR", "=value", "="])
+    def test_malformed_env_var_raises(self, tmp_path, bad):
+        # No '=' at all, or an empty key (e.g. "=value") both violate KEY=VALUE.
+        f = tmp_path / "s.yaml"
+        f.write_text(SDL_YAML)
+        with pytest.raises(RuntimeError, match="expected KEY=VALUE"):
+            _prepare_sdl_content(str(f), env_vars=[bad])
+
     def test_image_override_does_not_target_comment_line(self, tmp_path):
         # The override regex is `image:\s+[^\n]+` with count=1, so it replaces
         # the FIRST occurrence of "image: " anywhere in the file. A YAML comment

--- a/tests/test_update_flow.py
+++ b/tests/test_update_flow.py
@@ -161,3 +161,26 @@ class TestDeployDepositGuard:
         with pytest.raises(RuntimeError, match="Invalid deposit"):
             deploy(sdl_path="ignored.yaml", deposit=0)
         MockAPI.return_value.create_deployment.assert_not_called()
+
+
+class TestResolveSdlPath:
+    def test_gpu_uses_variant_when_present(self, tmp_path):
+        from just_akash.deploy import _resolve_sdl_path
+
+        (tmp_path / "app.yaml").write_text("base")
+        (tmp_path / "app-gpu.yaml").write_text("gpu")
+        assert _resolve_sdl_path(str(tmp_path / "app.yaml"), gpu=True) == str(
+            tmp_path / "app-gpu.yaml"
+        )
+
+    def test_gpu_falls_back_when_no_variant(self, tmp_path):
+        from just_akash.deploy import _resolve_sdl_path
+
+        (tmp_path / "app.yaml").write_text("base")
+        base = str(tmp_path / "app.yaml")
+        assert _resolve_sdl_path(base, gpu=True) == base
+
+    def test_no_gpu_returns_original(self):
+        from just_akash.deploy import _resolve_sdl_path
+
+        assert _resolve_sdl_path("/x/app.yaml", gpu=False) == "/x/app.yaml"


### PR DESCRIPTION
## Summary

Fixes every finding from the deep evaluation of `main`. Each is a real correctness or safety issue in the deploy loop or transports, with a focused test.

### Robustness / safety
- **`lease_shell._recv_proxy_message`** — guard against non-dict JSON (`"[1,2,3]"`, `"null"`, `"42"`) and base64 decode errors. Previously these crashed the recv loop uncaught.
- **`deploy._redeploy_and_reselect`** — if closing the stale order fails, retry 3× then **abort** (raise) rather than proceeding. Proceeding risked **double escrow**; the error now surfaces the manual-cleanup command.
- **`lease_shell._stream` (`logs --follow`)** — reconnect on JWT auth-expiry, mirroring the interactive `_exec_loop`, so long-running log tails survive token rotation.
- **`deploy._prepare_sdl_content`** — validate `--env` values are `KEY=VALUE`; fail fast instead of emitting a malformed SDL.

### Correctness / UX
- **`deploy._resolve_sdl_path`** — when `--gpu` is set, prefer a `<name>-gpu<ext>` SDL variant if it exists (warn + fall back otherwise).
- **`ssh.SSHTransport.inject`** — `shlex.quote` the remote path in all three commands (mkdir/cat/chmod), matching the lease-shell transport and CLI.

### Docs
- **`SECURITY.md`** — document the lease-shell `inject` base64-argv exposure window on the provider host's process table (operator/co-tenant threat on a trusted host).

## Tests
recv-loop robustness · logs reconnect-on-auth-expiry (and no-reconnect on a non-auth close) · close-retry-then-abort (+ retry-then-succeed) · `--env` validation · `_resolve_sdl_path` variants · SSH inject path-quoting · a re-deploy path that leases a **BACKUP**-tier bid on the re-created order (previously uncovered).

## Gate
`ruff check` ✓ · `ruff format --check` ✓ · `pyright` 0 errors ✓ · `pytest` 774 passed ✓ · `.secrets.baseline` regenerated for pure line drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU-aware SDL file selection when using `--gpu` flag.
  * Added automatic reconnection on authentication token expiry during log streaming.

* **Bug Fixes**
  * Fixed SSH path handling to prevent shell injection vulnerabilities.
  * Enhanced environment variable validation before SDL modification.
  * Improved stale order closure with retry logic to prevent double-escrow scenarios.

* **Documentation**
  * Added security guidance on secret transmission and exposure limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->